### PR TITLE
敵のHPバーとコンボ数の表記の位置調整

### DIFF
--- a/Assets/Prefabs/UI/ComboUI.prefab
+++ b/Assets/Prefabs/UI/ComboUI.prefab
@@ -298,7 +298,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 6.9000015, y: -89.483604}
+  m_AnchoredPosition: {x: 6.899994, y: -89.483604}
   m_SizeDelta: {x: 117.7134, y: 114.23001}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &1854358559124729381

--- a/Assets/Prefabs/UI/InGameUICanvas.prefab
+++ b/Assets/Prefabs/UI/InGameUICanvas.prefab
@@ -412,7 +412,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -100.03}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5653411042876740993
@@ -428,7 +428,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _healthBarPrefab: {fileID: 8904241971001950680, guid: d256e58c4cbaa80479e4979b6e5a5214, type: 3}
-  _initialPosition: {x: 0, y: 30}
+  _initialPosition: {x: 0, y: -40}
   _defaultScale: {x: 1, y: 1, z: 1}
   _showDuration: 0.2
   _hideDuration: 0.15
@@ -494,7 +494,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _ringIndicatorData: {fileID: 11400000, guid: 450d1063b9645b545925918aeec006ec, type: 2}
-  _apearSound: {fileID: 8300000, guid: e7408793083e07d40b274a4c4921866b, type: 3}
 --- !u!1 &2313999795422903739
 GameObject:
   m_ObjectHideFlags: 0
@@ -1336,7 +1335,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5405946735788268101, guid: 21bcd27fde247c3478b0bbdf453fb730, type: 3}
       propertyPath: m_Pivot.x
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5405946735788268101, guid: 21bcd27fde247c3478b0bbdf453fb730, type: 3}
       propertyPath: m_Pivot.y
@@ -1344,7 +1343,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5405946735788268101, guid: 21bcd27fde247c3478b0bbdf453fb730, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5405946735788268101, guid: 21bcd27fde247c3478b0bbdf453fb730, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1352,7 +1351,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5405946735788268101, guid: 21bcd27fde247c3478b0bbdf453fb730, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5405946735788268101, guid: 21bcd27fde247c3478b0bbdf453fb730, type: 3}
       propertyPath: m_AnchorMin.y
@@ -1396,11 +1395,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5405946735788268101, guid: 21bcd27fde247c3478b0bbdf453fb730, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 635.3467
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 5405946735788268101, guid: 21bcd27fde247c3478b0bbdf453fb730, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 52.18822
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 5405946735788268101, guid: 21bcd27fde247c3478b0bbdf453fb730, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x


### PR DESCRIPTION
※他のUIの調整をやるとPRが長くなるかもしれないので、UIの配置変更のみでPRを作成

[変更内容]

- 敵のHPバーを、メカに被らないくらい上に移動
- RectTransformやSirializeFieldでの値指定がぐちゃぐちゃだったので整理。SirializeFieldでY軸の位置を指定するようにした
- コンボ数を右端に寄せた

[影響範囲]

- 特になし

