### PR TITLE
フェーズ3のボスのサイズが小さすぎて見えない問題を修正

### DIFF
--- a/Assets/Scenes/Master/Battle.unity
+++ b/Assets/Scenes/Master/Battle.unity
@@ -406,33 +406,49 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 469800026}
     m_Modifications:
-    - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -5.83409
+    - target: {fileID: 2437228545276813613, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 70
       objectReference: {fileID: 0}
-    - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
+    - target: {fileID: 2437228545276813613, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 70
       objectReference: {fileID: 0}
-    - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 6.4802
+    - target: {fileID: 2437228545276813613, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 70
       objectReference: {fileID: 0}
-    - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
-      propertyPath: m_LocalRotation.w
+    - target: {fileID: 2437228545276813613, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
+      propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.7741
+      objectReference: {fileID: 0}
+    - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.625
+      objectReference: {fileID: 0}
+    - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.095845714
+      objectReference: {fileID: 0}
+    - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: 0.99539626
       objectReference: {fileID: 0}
     - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4608565393059296414, guid: 8e380c9dae5fae54c80fe970b684227d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x


### PR DESCRIPTION
[不具合の詳細]
- フェーズ3のボスがいない

[原因]
- オブジェクトのScaleが、他のPhase1、2のボスのオブジェクトと異なっていた

[影響範囲]
- 特になし