### PR TITLE
フェーズが切り替わったときにゾーンゲージをリセットする処理を追加

### DIFF
--- a/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/FlowZoneSystem.cs
+++ b/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/FlowZoneSystem.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using BeatKeeper.Runtime.Ingame.System;
+using Cysharp.Threading.Tasks;
 using R3;
+using SymphonyFrameWork.System;
 using UnityEngine;
 
 namespace BeatKeeper.Runtime.Ingame.Character
@@ -22,6 +24,8 @@ namespace BeatKeeper.Runtime.Ingame.Character
             }
 
             _data = data; // フローゾーンの継続時間を拍数で指定
+
+            SetupPhaseManagerAsync().Forget();
         }
 
         ~FlowZoneSystem()
@@ -82,9 +86,31 @@ namespace BeatKeeper.Runtime.Ingame.Character
         /// </summary>
         private readonly ReactiveProperty<bool> _isFlowZone = new();
 
+        private PhaseManager _phaseManager;
+        private CompositeDisposable _disposable = new();
         private int _count;
 
+        private async UniTask SetupPhaseManagerAsync()
+        {
+            _phaseManager = await ServiceLocator.GetInstanceAsync<PhaseManager>();
 
+            if (_phaseManager == null)
+            {
+                Debug.LogError($"[{typeof(FlowZoneSystem)}] PhaseManager が取得できませんでした");
+                return;
+            }
+            _phaseManager.CurrentPhaseProp.Subscribe(ResetResonanceCount).AddTo(_disposable);
+            
+        }
+
+        /// <summary>
+        ///     ゾーンカウントをリセットする
+        /// </summary>
+        private void ResetResonanceCount(PhaseEnum phase)
+        {
+            _resonanceCount.Value = 0;
+        }
+        
         /// <summary>
         ///     拍数が変更されるタイミングで呼び出されるメソッド
         /// </summary>

--- a/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/FlowZoneSystem.cs
+++ b/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/FlowZoneSystem.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using BeatKeeper.Runtime.Ingame.System;
-using Cysharp.Threading.Tasks;
 using R3;
-using SymphonyFrameWork.System;
 using UnityEngine;
 
 namespace BeatKeeper.Runtime.Ingame.Character
@@ -24,8 +22,6 @@ namespace BeatKeeper.Runtime.Ingame.Character
             }
 
             _data = data; // フローゾーンの継続時間を拍数で指定
-
-            SetupPhaseManagerAsync().Forget();
         }
 
         ~FlowZoneSystem()
@@ -72,6 +68,14 @@ namespace BeatKeeper.Runtime.Ingame.Character
                 EndFlowZone();
             }
         }
+        
+        /// <summary>
+        ///     ゾーンカウントをリセットする
+        /// </summary>
+        public void ResetResonanceCount()
+        {
+            _resonanceCount.Value = 0;
+        }
 
         private readonly PlayerData _data;
         private readonly BGMManager _musicEngineHelper;
@@ -86,30 +90,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
         /// </summary>
         private readonly ReactiveProperty<bool> _isFlowZone = new();
 
-        private PhaseManager _phaseManager;
-        private CompositeDisposable _disposable = new();
         private int _count;
-
-        private async UniTask SetupPhaseManagerAsync()
-        {
-            _phaseManager = await ServiceLocator.GetInstanceAsync<PhaseManager>();
-
-            if (_phaseManager == null)
-            {
-                Debug.LogError($"[{typeof(FlowZoneSystem)}] PhaseManager が取得できませんでした");
-                return;
-            }
-            _phaseManager.CurrentPhaseProp.Subscribe(ResetResonanceCount).AddTo(_disposable);
-            
-        }
-
-        /// <summary>
-        ///     ゾーンカウントをリセットする
-        /// </summary>
-        private void ResetResonanceCount(PhaseEnum phase)
-        {
-            _resonanceCount.Value = 0;
-        }
         
         /// <summary>
         ///     拍数が変更されるタイミングで呼び出されるメソッド

--- a/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
+++ b/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
@@ -285,6 +285,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
             else
             {
                 _flowZoneSystem.ResetFlowZone();
+                _flowZoneSystem.ResetResonanceCount();
             }
         }
 

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/UIElement_ResonanceMeter.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/UIElement_ResonanceMeter.cs
@@ -82,9 +82,16 @@ namespace BeatKeeper
         {
             count--; // カウントが1オリジンで渡ってくるので、1減らす処理を挟む
 
-            if (count < -1 || count >= _icons.Length) // 0-6の範囲に収めたい
+            if (count >= _icons.Length) // 0-6の範囲に収めたい
             {
                 Debug.LogError("[リズム共鳴メーター] 共鳴回数の範囲外です");
+                return;
+            }
+
+            if (count == -1)
+            {
+                // フローゾーンゲージのカウントがリセットされた場合、UIも全て暗い色に変更
+                AllReset();
                 return;
             }
 

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/UIElement_ResonanceMeter.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/UIElement_ResonanceMeter.cs
@@ -80,18 +80,18 @@ namespace BeatKeeper
         /// </summary>
         private void IconColorChanged(int count)
         {
-            count--; // カウントが1オリジンで渡ってくるので、1減らす処理を挟む
-
-            if (count >= _icons.Length) // 0-6の範囲に収めたい
-            {
-                Debug.LogError("[リズム共鳴メーター] 共鳴回数の範囲外です");
-                return;
-            }
-
-            if (count == -1)
+            if (count == 0)
             {
                 // フローゾーンゲージのカウントがリセットされた場合、UIも全て暗い色に変更
                 AllReset();
+                return;
+            }
+            
+            count--; // カウントが1オリジンで渡ってくるので、1減らす処理を挟む
+
+            if (count < -1 || count >= _icons.Length) // 0-6の範囲に収めたい
+            {
+                Debug.LogError("[リズム共鳴メーター] 共鳴回数の範囲外です");
                 return;
             }
 


### PR DESCRIPTION
[変更内容]
- フェーズが切り替わったときにゾーンゲージをリセットする処理を追加

[影響範囲]
- フローゾーンのシステム内（PlayerManagerに変更がないような書き換え方をしているので、書き方は汚いかも）
- ゾーンゲージのUIクラス内

[確認項目]
- 数回起動しなおしてみて、PhaseManagerがきちんと取得されることを確認
- ブレイクムービーに入ったタイミングでStateが変わるので、その時にゾーンゲージがリセットされる
- Phase3つやって、しっかり動くことを確認