### PR TITLE
GetBeatNearerSinceStartの修正に合わせて、ノーツの当たりアニメーションの実行条件の判定方法を修正

### DIFF
--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -82,8 +82,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         private void InitializeComponents()
         {
             ResetAllComponents();
-            
-            _timing = MusicEngineHelper.GetBeatSinceStart();
 
             _tweens = new Tween[5];
 
@@ -185,11 +183,11 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// </summary>
         private void OnPlayerAttackSuccess()
         {
-            if (_timing + CHARGE_TIME >= MusicEngineHelper.GetBeatSinceStart())
+            if (MusicEngineHelper.GetBeatNearerSinceStart() != _timing)
             {
-                // チャージ完了タイミングより前なら処理はスキップ
+                // ノーツのタイミングより前なら処理はスキップ
                 return;
-            }
+            }   
             
             // 他のすべてのTweenをキル
             for (int i = 0; i < _tweens.Length; i++)

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -81,9 +81,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// </summary>
         private void InitializeComponents()
         {
-            // 生成時点のタイミングを保存
-            _timing = MusicEngineHelper.GetBeatSinceStart();
-
             // Tweenの配列を作成
             _tweens = new Tween[3];
 

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -138,8 +138,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         private const float RECEPTION_TIME = 0.45f;
 
         [SerializeField] private Image[] _ringImages = new Image[2];
-        // 譜面の長さ
-        private int _chartLength => _chartRingManager.TargetData.ChartData.Chart.Length;
 
         private void Start()
         {
@@ -197,7 +195,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// </summary>
         private void OnPlayerAttackSuccess(bool isPerfect)
         {
-            if (MusicEngineHelper.GetBeatNearerSinceStart() % _chartLength != _timing)
+            if (MusicEngineHelper.GetBeatNearerSinceStart() != _timing)
             {
                 // ノーツのタイミングより前なら処理はスキップ
                 return;

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -160,7 +160,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// </summary>
         private void PlaySuccessEffect()
         {
-            if (MusicEngineHelper.GetBeatNearerSinceStart() % _chartLength != _timing)
+            if (MusicEngineHelper.GetBeatNearerSinceStart() != _timing)
             {
                 // ノーツのタイミングより前なら処理はスキップ
                 return;


### PR DESCRIPTION
内容については、Discordの共有通り

- フェーズ3まで通してクリアできること
- チュートリアルを入れても問題なく作動すること

確認しました