### PR TITLE
ノーツクラスのリファクタリングとバグとり

### DIFF
--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -63,6 +63,20 @@ namespace BeatKeeper.Runtime.Ingame.UI
             ResetAllComponents();
         }
         
+        #region チュートリアル用のメソッド
+        
+        /// <summary>
+        /// チャージ演出
+        /// </summary>
+        public void OnPlayerChargeTutorial() => OnPlayerChargeForced();
+
+        /// <summary>
+        /// 長押し成功演出
+        /// </summary>
+        public void OnPlayerAttackSuccessTutorial() => OnPlayerAttackSuccessForced();
+        
+        #endregion
+        
         private const float CONTRACTION_SPEED = 2; // 始点リングの収束にかける拍数
         private const float CHARGE_TIME = 2; // チャージにかかる拍
         private const float RECEPTION_TIME = 0.45f; // Justタイミングのあとの判定受付時間 // TODO: PlayerDataから値をとってくるようにする
@@ -91,8 +105,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _player.OnChargeAttack += OnPlayerAttackSuccess; // チャージ完了したあとに攻撃
             _player.OnMissChargeAttack += PlayFailEffect; // チャージ完了前に攻撃（=チャージ攻撃失敗）
         }
-
-        #region ベースとなる演出
         
         /// <summary>
         /// 始点リングの縮小演出
@@ -125,66 +137,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _tweens[2] = blurPulseSequence;
         }
 
-        #endregion
-
-        public void OnPlayerChargeTutorial()
-        {
-            if (_tweens != null)
-            {
-                // 進行中の縮小以外の演出を停止。最終値に到達させた状態にする
-                _tweens[0]?.Kill();
-            }
-
-            var beatDuration = (float)MusicEngineHelper.DurationOfBeat;
-            var totalDuration = beatDuration * CHARGE_TIME;
-
-            // マスクのスケールを外側リングの大きさに合わせる
-            _endPositionRing.rectTransform.localScale = _ringImage.rectTransform.localScale;
-
-            var sequence = DOTween.Sequence()
-
-                // 色変更（チャージ開始時）
-                .Append(_ringImage.DOColor(_chargeColor, totalDuration * 0.1f).SetEase(Ease.OutFlash)) // 縮小するリング
-                .Join(_decorationImage.DOColor(_chargeColor, totalDuration * 0.1f).SetEase(Ease.OutFlash)) // 縮小するリングの発光部分
-                .Join(_startPositionRing.DOColor(_chargeColor, totalDuration * 0.1f).SetEase(Ease.OutFlash)) // 自身
-
-                // メインのリング移動アニメーション（外側リングから内側リングへ）
-                .Append(_ringImage.rectTransform.DOScale(_centerRingsScale, totalDuration * 0.9f).SetEase(Ease.OutQuart))
-
-                // 必要に応じて位置も調整
-                .Join(_startPositionRing.rectTransform.DOMove(_endPositionRing.transform.position, totalDuration * 0.9f).SetEase(Ease.Linear))
-
-                .OnComplete(OnChargeComplete);
-
-            _tweens[1] = sequence;
-        }
-        public void OnPlayerAttackSuccessTutorial()
-        {
-            // 他のすべてのTweenをキル
-            for (int i = 0; i < _tweens.Length; i++)
-            {
-                _tweens[i]?.Kill();
-            }
-            
-            HandleCenterImage(true);
-            // 色とテキストが変更されていない場合、念のためここで変えておく
-            ResetRingsColor(_newColor, _newColor);
-
-            var sequence = DOTween.Sequence()
-
-                // 拡大
-                .Append(_startPositionRing.rectTransform.DOScale(_centerRingsScale * 1.05f, _blinkDuration * 0.4f).SetEase(Ease.OutBack))
-                .Join(_ringImage.rectTransform.DOScale(Vector3.one * _initialScale * 1.05f, _blinkDuration * 0.4f).SetEase(Ease.OutBack))
-                .Join(_decorationImage.rectTransform.DOScale(_centerRingsScale * 1.05f, _blinkDuration * 0.4f).SetEase(Ease.OutBack))
-
-                // フェードアウト
-                .Join(CreateFadeSequence(_fadeDuration))
-
-                .OnComplete(End);
-
-            _tweens[3] = sequence;
-        }
-
         /// <summary>
         /// チャージ中の演出
         /// </summary>
@@ -195,7 +147,15 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 // ノーツのタイミングより前なら処理はスキップ
                 return;
             }
+            
+            OnPlayerChargeForced();
+        }
 
+        /// <summary>
+        /// 強制的にチャージ演出を実行
+        /// </summary>
+        private void OnPlayerChargeForced()
+        {
             if (_tweens != null)
             {
                 // 進行中の縮小以外の演出を停止。最終値に到達させた状態にする
@@ -211,17 +171,17 @@ namespace BeatKeeper.Runtime.Ingame.UI
             var sequence = DOTween.Sequence()
                 
                 // 色変更（チャージ開始時）
- 	     	 	.Append(_ringImage.DOColor(_chargeColor, totalDuration * 0.1f).SetEase(Ease.OutFlash)) // 縮小するリング
-	    	    .Join(_decorationImage.DOColor(_chargeColor, totalDuration * 0.1f).SetEase(Ease.OutFlash)) // 縮小するリングの発光部分
- 	       		.Join(_startPositionRing.DOColor(_chargeColor, totalDuration * 0.1f).SetEase(Ease.OutFlash)) // 自身
+                .Append(_ringImage.DOColor(_chargeColor, totalDuration * 0.1f).SetEase(Ease.OutFlash)) // 縮小するリング
+                .Join(_decorationImage.DOColor(_chargeColor, totalDuration * 0.1f).SetEase(Ease.OutFlash)) // 縮小するリングの発光部分
+                .Join(_startPositionRing.DOColor(_chargeColor, totalDuration * 0.1f).SetEase(Ease.OutFlash)) // 自身
         
-        		// メインのリング移動アニメーション（外側リングから内側リングへ）
-        		.Append(_ringImage.rectTransform.DOScale(_centerRingsScale, totalDuration * 0.9f).SetEase(Ease.OutQuart))
+                // メインのリング移動アニメーション（外側リングから内側リングへ）
+                .Append(_ringImage.rectTransform.DOScale(_centerRingsScale, totalDuration * 0.9f).SetEase(Ease.OutQuart))
         
-       			// 必要に応じて位置も調整
-        		.Join(_startPositionRing.rectTransform.DOMove(_endPositionRing.transform.position, totalDuration * 0.9f).SetEase(Ease.Linear))
+                // 必要に応じて位置も調整
+                .Join(_startPositionRing.rectTransform.DOMove(_endPositionRing.transform.position, totalDuration * 0.9f).SetEase(Ease.Linear))
 
-		        .OnComplete(OnChargeComplete);
+                .OnComplete(OnChargeComplete);
             
             _tweens[1] = sequence;
         }
@@ -247,16 +207,28 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 // ノーツのタイミングより前なら処理はスキップ
                 return;
             }
-            
+
+            OnPlayerAttackSuccessForced();
+        }
+
+        /// <summary>
+        /// 当たりエフェクトを強制再生
+        /// TODO: 後に長押しノーツの判定のPlayerManager側が完成したら修正するかも
+        /// </summary>
+        private void OnPlayerAttackSuccessForced()
+        {
             // 他のすべてのTweenをキル
             for (int i = 0; i < _tweens.Length; i++)
             {
                 _tweens[i]?.Kill();
             }
             
+            // 中央の画像を判定用の画像に変更
+            // TODO: 判定に合わせて引数に渡す変数を変更する
             HandleCenterImage(true);
-            // 色とテキストが変更されていない場合、念のためここで変えておく
-            ResetRingsColor(_newColor, _newColor);
+            
+            // 色変更前に白色のSpriteに変更
+            ChangeRingsImage();
            
             var sequence = DOTween.Sequence()
                 
@@ -264,6 +236,9 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 .Append(_startPositionRing.rectTransform.DOScale(_centerRingsScale * 1.05f, _blinkDuration * 0.4f).SetEase(Ease.OutBack))
                 .Join(_ringImage.rectTransform.DOScale(Vector3.one * _initialScale * 1.05f, _blinkDuration * 0.4f).SetEase(Ease.OutBack))
                 .Join(_decorationImage.rectTransform.DOScale(_centerRingsScale * 1.05f, _blinkDuration * 0.4f).SetEase(Ease.OutBack))
+                
+                // 色変更
+                .Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration))
                 
                 // フェードアウト
                 .Join(CreateFadeSequence(_fadeDuration))
@@ -302,12 +277,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// </summary>
         private void ResetAllComponents()
         {
-            // スケールをリセット
-            ResetRingsScale();
-            
-            // 色をデフォルトに設定
-            ResetRingsColor(_defaultColor, _translucentDefaultColor);
-            
             SetAllAlpha(0f);
 
 			// 移動するオブジェクトの位置を変更

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -78,8 +78,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
 		// 譜面の長さ
         private int _chartLength => _chartRingManager.TargetData.ChartData.Chart.Length;
-
-        
         
         /// <summary>
         /// コンポーネントの初期化

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -16,7 +16,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
 		public override void OnGet(Action onEndAction, Vector2 startPosition, Vector2 endPosition, int timing)
 		{
 			base.OnGet(onEndAction, startPosition, endPosition, timing);
-
+            
 			// 始点リングの位置を設定
 			_startPositionRing.rectTransform.position = startPosition
                                                 + new Vector2(Screen.width / 2, Screen.height / 2);
@@ -37,7 +37,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             {
                 // 縮小エフェクトを開始する
                 case 1:
-                    InitializeComponents();
                     StartContractionEffect();
                     break;
             }
@@ -82,7 +81,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// コンポーネントの初期化
         /// </summary>
-        protected virtual void InitializeComponents()
+        protected override void InitializeComponents()
         {
             ResetAllComponents();
             

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -365,7 +365,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// フェードアウトシーケンスを作成
         /// </summary>
-        private DG.Tweening.Sequence CreateFadeSequence(float duration)
+        protected override DG.Tweening.Sequence CreateFadeSequence(float duration)
         {
             var fadeSequence = DOTween.Sequence();
             
@@ -381,7 +381,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// 色変更シーケンスを作成
         /// </summary>
-        private DG.Tweening.Sequence CreateColorChangeSequence(Color targetColor, Color translucentColor,
+        protected override DG.Tweening.Sequence CreateColorChangeSequence(Color targetColor, Color translucentColor,
             float duration)
         {
             var colorSequence = DOTween.Sequence();

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -98,21 +98,13 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// 始点リングの縮小演出
         /// </summary>
-        private void StartContractionEffect()
+        protected virtual void StartContractionEffect()
         {
             var beatDuration = (float)MusicEngineHelper.DurationOfBeat;
             
             // 表示
             SetAllAlpha(1f);
             
-            // ブラーリングのパルス
-            var blurPulseSequence = DOTween.Sequence()
-                .Append(_decorationImage.DOFade(_translucentDefaultColor.a * 1.5f, beatDuration * 0.5f).SetEase(Ease.OutSine))
-                .Append(_decorationImage.DOFade(_translucentDefaultColor.a, beatDuration * 0.5f).SetEase(Ease.InSine))
-                .SetLoops(-1, LoopType.Restart);
-            
-            _tweens[2] = blurPulseSequence;
-
             var sequence = DOTween.Sequence()
                 
                 // 縮小開始（完全には収縮しきらないようにする）
@@ -124,6 +116,14 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 .OnComplete(() => PlayFailEffect());
             
             _tweens[0] = sequence;
+            
+            // ブラーリングのパルス
+            var blurPulseSequence = DOTween.Sequence()
+                .Append(_decorationImage.DOFade(_translucentDefaultColor.a * 1.5f, beatDuration * 0.5f).SetEase(Ease.OutSine))
+                .Append(_decorationImage.DOFade(_translucentDefaultColor.a, beatDuration * 0.5f).SetEase(Ease.InSine))
+                .SetLoops(-1, LoopType.Restart);
+            
+            _tweens[2] = blurPulseSequence;
         }
 
         #endregion

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -98,43 +98,13 @@ namespace BeatKeeper.Runtime.Ingame.UI
         protected override void InitializeComponents()
         {
             ResetAllComponents();
+            SetAllAlpha(1f);
             
             _tweens = new Tween[5];
 
             _player.OnStartChargeAttack += OnPlayerCharge; // チャージ開始
             _player.OnChargeAttack += OnPlayerAttackSuccess; // チャージ完了したあとに攻撃
             _player.OnMissChargeAttack += PlayFailEffect; // チャージ完了前に攻撃（=チャージ攻撃失敗）
-        }
-        
-        /// <summary>
-        /// 始点リングの縮小演出
-        /// </summary>
-        protected virtual void StartContractionEffect()
-        {
-            var beatDuration = (float)MusicEngineHelper.DurationOfBeat;
-            
-            // 表示
-            SetAllAlpha(1f);
-            
-            var sequence = DOTween.Sequence()
-                
-                // 縮小開始（完全には収縮しきらないようにする）
-                .Append(_ringImage.rectTransform.DOScale(_centerRingsScale, beatDuration * CONTRACTION_SPEED).SetEase(Ease.Linear))
-                
-                // Just判定後も縮小を続ける
-                .Append(_ringImage.rectTransform.DOScale(_centerRingsScale, beatDuration * RECEPTION_TIME).SetEase(Ease.Linear))
-                
-                .OnComplete(() => PlayFailEffect());
-            
-            _tweens[0] = sequence;
-            
-            // ブラーリングのパルス
-            var blurPulseSequence = DOTween.Sequence()
-                .Append(_decorationImage.DOFade(_translucentDefaultColor.a * 1.5f, beatDuration * 0.5f).SetEase(Ease.OutSine))
-                .Append(_decorationImage.DOFade(_translucentDefaultColor.a, beatDuration * 0.5f).SetEase(Ease.InSine))
-                .SetLoops(-1, LoopType.Restart);
-            
-            _tweens[2] = blurPulseSequence;
         }
 
         /// <summary>
@@ -183,7 +153,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
                 .OnComplete(OnChargeComplete);
             
-            _tweens[1] = sequence;
+            _tweens[0] = sequence;
         }
 
         /// <summary>
@@ -240,7 +210,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 // 色変更
                 .Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration))
                 
-                // フェードアウト
+                // フェードアウト NOTE: 他のノーツと違いここの連結をJoinとしている
                 .Join(CreateFadeSequence(_fadeDuration))
                 
                 .OnComplete(End);
@@ -360,7 +330,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
             if (_decorationImage != null)
             {
                 // Kill the pulse animation and set the alpha to a static value.
-                _tweens[2]?.Kill();
+                _tweens[1]?.Kill();
                 var color = _decorationImage.color;
                 color.a = _translucentDefaultColor.a;
                 _decorationImage.color = color;
@@ -378,7 +348,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
                     .Append(_decorationImage.DOFade(_translucentDefaultColor.a * 1.5f, beatDuration * 0.5f).SetEase(Ease.OutSine))
                     .Append(_decorationImage.DOFade(_translucentDefaultColor.a, beatDuration * 0.5f).SetEase(Ease.InSine))
                     .SetLoops(-1, LoopType.Restart);
-                _tweens[2] = blurPulseSequence;
+                _tweens[1] = blurPulseSequence;
             }
         }
 

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -82,7 +82,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// コンポーネントの初期化
         /// </summary>
-        private void InitializeComponents()
+        protected virtual void InitializeComponents()
         {
             ResetAllComponents();
             

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -360,7 +360,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         
         #endregion
 
-        #region Create Tween
+        #region シーケンス作成メソッド
 
         /// <summary>
         /// フェードアウトシーケンスを作成

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -298,8 +298,18 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _tweens[0] = sequence;
         }
 
-        #region Reset
-
+        /// <summary>
+        /// 全要素のアルファ値設定
+        /// </summary>
+        private void SetAllAlpha(float alpha)
+        {
+            if(_ringImage != null) _ringImage.color = new Color(_ringImage.color.r, _ringImage.color.g, _ringImage.color.b, alpha);
+            if(_startPositionRing != null) _startPositionRing.color = new Color(_startPositionRing.color.r, _startPositionRing.color.g, _startPositionRing.color.b, alpha);
+            if(_endPositionRing != null) _endPositionRing.color = new Color(_endPositionRing.color.r, _endPositionRing.color.g, _endPositionRing.color.b, alpha);
+            if(_decorationImage != null) _decorationImage.color = new Color(_decorationImage.color.r, _decorationImage.color.g, _decorationImage.color.b, alpha);
+            if(_centerImage != null) _centerImage.color = new Color(_centerImage.color.r, _centerImage.color.g, _centerImage.color.b, alpha);
+        }
+        
         /// <summary>
         /// 全コンポーネントの完全初期化
         /// </summary>
@@ -317,10 +327,12 @@ namespace BeatKeeper.Runtime.Ingame.UI
 			_startPositionRing.transform.position = transform.position;
         }
         
+        #region リングのコンポーネント全てのScale、色のリセット
+        
         /// <summary>
         /// 各リングの拡大率を変更する
         /// </summary>
-        private void ResetRingsScale()
+        protected override void ResetRingsScale()
         {
             // 収縮する一番外側のリング
             if(_ringImage != null) _ringImage.rectTransform.localScale = Vector3.one * _initialScale;
@@ -336,7 +348,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// 各リングの色を変更する
         /// </summary>
-        private void ResetRingsColor(Color color, Color translucentColor)
+        protected override void ResetRingsColor(Color color, Color translucentColor)
         {
             // NOTE: マスクの画像は色を変える必要がないのでここには書いていない
             if(_ringImage != null) _ringImage.color = color;
@@ -346,18 +358,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             if(_centerImage != null) _centerImage.color = Color.white;
         }
 
-        /// <summary>
-        /// 全要素のアルファ値設定
-        /// </summary>
-        private void SetAllAlpha(float alpha)
-        {
-            if(_ringImage != null) _ringImage.color = new Color(_ringImage.color.r, _ringImage.color.g, _ringImage.color.b, alpha);
-            if(_startPositionRing != null) _startPositionRing.color = new Color(_startPositionRing.color.r, _startPositionRing.color.g, _startPositionRing.color.b, alpha);
-            if(_endPositionRing != null) _endPositionRing.color = new Color(_endPositionRing.color.r, _endPositionRing.color.g, _endPositionRing.color.b, alpha);
-            if(_decorationImage != null) _decorationImage.color = new Color(_decorationImage.color.r, _decorationImage.color.g, _decorationImage.color.b, alpha);
-            if(_centerImage != null) _centerImage.color = new Color(_centerImage.color.r, _centerImage.color.g, _centerImage.color.b, alpha);
-        }
-        
         #endregion
 
         #region シーケンス作成メソッド

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -285,17 +285,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
             {
                 _tweens[i]?.Kill();
             }
-            
-            var sequence = DOTween.Sequence()
-                
-                .Append(_startPositionRing.rectTransform.DOScale(_centerRingsScale * 0.6f, _fadeDuration * 0.3f).SetEase(Ease.InQuad))
-                .Join(_ringImage.rectTransform.DOScale(Vector3.one * _initialScale * 0.7f, _fadeDuration * 0.3f).SetEase(Ease.InQuad))
-                
-                // フェードアウト
-                .Append(CreateFadeSequence(_fadeDuration * 0.7f))
-                .OnComplete(End);
-            
-            _tweens[0] = sequence;
+            base.PlayFailEffect();
         }
 
         /// <summary>

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/ChargeIndicator.cs
@@ -279,7 +279,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// 失敗演出（チャージ完了前に終了）
         /// </summary>
-        public void PlayFailEffect()
+        public override void PlayFailEffect()
         {
             for (int i = 0; i < 3; i++)
             {

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -154,6 +154,12 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// </summary>
         public void OnPlayerAvoidSuccess(bool isPerfect)
         {
+            if (MusicEngineHelper.GetBeatNearerSinceStart() != _timing)
+            {
+                // ノーツのタイミングより前なら処理はスキップ
+                return;
+            }
+            
 			// 成功した場合はリングの縮小演出は不要になるのでキル
             if(_tweens != null)
 			{
@@ -173,8 +179,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
             // パンチスケール
             successSequence.Append(_selfImage.rectTransform.DOPunchScale(Vector3.one * 0.65f, _blinkDuration, 2, 0.5f));
-
-            // 色変更とフェードアウト
             successSequence.Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration));
 
 			// フェードアウト
@@ -183,11 +187,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
             // エフェクトが完了したらEnd処理を実行
             successSequence.OnComplete(End);
 
-            // Tweenを配列に保存
-            if (_tweens != null && _tweens.Length > 2)
-            {
-                _tweens[2] = successSequence;
-            }
+            _tweens[0] = successSequence;
         }
 
 		protected override void HandlePerfect() => OnPlayerAvoidSuccess(true);

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -21,12 +21,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         {
             base.Effect(count);
 
-            if (_isFailed)
-            {
-                // 回避失敗していたらreturn
-                return;
-            }
-
             switch (count)
             {
                 // 1拍目　点滅して表示 -> 1拍目から縮小するように修正
@@ -47,11 +41,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
         public override void End()
         {
-            // フラグリセット
-            _isFailed = false;
-
-            ResetAllTween();
-
             // イベント購読解除
             _player.OnPerfectAvoid -= HandlePerfect;
             _player.OnGoodAvoid -= HandleGood;
@@ -73,8 +62,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
         [Header("追加の色設定")]
         [SerializeField] private Color _warningColor = Color.red;
-
-        private bool _isFailed; // 回避失敗フラグ
 
         private void Start()
         {
@@ -173,9 +160,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
 				_tweens[0]?.Kill();
 			}
 
-            // 他のアニメーションが再生されていたらキャンセル
-            ResetAllTween();
-
 			if (isPerfect)
             {
                 // パーフェクト判定の場合は収縮するリングのScaleを1に補正
@@ -215,12 +199,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             {
                 _tweens[0]?.Kill();
             }
-            
-            // 回避失敗フラグを立てる
-            _isFailed = true;
-
-            // 回避失敗したときに他のTweenが再生されていたら中断
-            ResetAllTween();
 			
 			SetMissImage();
 			
@@ -234,24 +212,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             
             _tweens[0] = failSequence;
         }
-
-        #region Reset
-
-        /// <summary>
-        /// Tweens配列をクリア
-        /// </summary>
-        private void ResetAllTween()
-        {
-            if (_tweens != null)
-            {
-                for (int i = 0; i < _tweens.Length; i++)
-                {
-                    _tweens[i] = null;
-                }
-            }
-        }
-
-        #endregion
 
 		protected override void HandlePerfect() => OnPlayerAvoidSuccess(true);
         protected override void HandleGood() => OnPlayerAvoidSuccess(false);

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -60,14 +60,10 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
         public void OnPlayerAvoidSuccess(bool isPerfect)
         {
-            OnPlayerSuccess(isPerfect);
+            OnPlayerSuccessForced(isPerfect);
         }
         
         #endregion
-
-        private const float CONTRACTION_SPEED = 2; // 収縮にかける拍
-		// Justタイミングのあとの判定受付時間 // TODO: PlayerDataから値をとってくるようにする
-        private const float RECEPTION_TIME = 0.45f;
 
         [Header("追加の色設定")]
         [SerializeField] private Color _warningColor = Color.red;
@@ -90,72 +86,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             // 初期状態の設定
             ResetRingsScale();
             ResetRingsColor(_defaultColor, _translucentDefaultColor);
-        }
-
-        /// <summary>
-        /// 1拍目　点滅シーケンス
-        /// </summary>
-        private void StartBlinkEffect()
-        {
-            var beatDuration = (float)MusicEngineHelper.DurationOfBeat;
-
-            var blinkSequence = DOTween.Sequence()
-
-                // 3回点滅
-                .Append(_ringImage.DOColor(_warningColor, _blinkDuration).SetLoops(3, LoopType.Yoyo))
-
-                // デフォルト色に戻す
-                .Append(_ringImage.DOColor(_defaultColor, 0.2f).SetEase(Ease.OutQuint));
-
-            // Tweenを配列に保存
-            if (_tweens != null && _tweens.Length > 0)
-            {
-                _tweens[0] = blinkSequence;
-            }
-        }
-
-        /// <summary>
-        ///リングの縮小
-        /// </summary>
-        private void StartContractionEffect()
-        {
-			if(_tweens != null)
-			{
-				// 点滅シーケンスをキル
-            	_tweens[0]?.Kill();
-			}
-
-            var beatDuration = (float)MusicEngineHelper.DurationOfBeat;
-
-            var contractionSequence = DOTween.Sequence();
-
-            // 縮小エフェクト
-            contractionSequence.Append(_ringImage.rectTransform.DOScale(Vector3.one, beatDuration * CONTRACTION_SPEED).SetEase(Ease.Linear));
-            
-			// Just判定を過ぎたら縮小は続行しつつ段々フェードアウトする
-			contractionSequence.Append(_ringImage.rectTransform.DOScale(Vector3.one * 0.5f, beatDuration * RECEPTION_TIME).SetEase(Ease.Linear));
-			contractionSequence.Join(CreateFadeSequence(beatDuration * RECEPTION_TIME));
-
-            // シーケンスが中断されなかった場合はミス。失敗演出を行う
-            contractionSequence.OnComplete(() => PlayFailEffect());
-            
-            // Tweenを配列に保存
-            if (_tweens != null && _tweens.Length > 1)
-            {
-                _tweens[0] = contractionSequence;
-            }
-
-            // ブラーリングのパルス
-            var blurPulseSequence = DOTween.Sequence()
-                .Append(_decorationImage.DOFade(_translucentDefaultColor.a * 1.5f, beatDuration * 0.5f).SetEase(Ease.OutSine))
-                .Append(_decorationImage.DOFade(_translucentDefaultColor.a, beatDuration * 0.5f).SetEase(Ease.InSine))
-                .SetLoops(-1, LoopType.Restart);
-
-            // Tweenを配列に保存
-            if (_tweens != null && _tweens.Length > 1)
-            {
-                _tweens[1] = blurPulseSequence;
-            }
         }
 
 		protected override void HandlePerfect() => OnPlayerSuccess(true);

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -251,29 +251,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             }
         }
 
-        /// <summary>
-        /// 各リングの拡大率をリセット
-        /// </summary>
-        private void ResetRingsScale()
-        {
-            if (_ringImage != null) _ringImage.rectTransform.localScale = Vector3.one * _initialScale;
-            if (_decorationImage != null) _decorationImage.rectTransform.localScale = Vector3.one;
-            if (_hitImage != null) _hitImage.rectTransform.localScale = Vector3.one;
-        }
-
-        /// <summary>
-        /// 各リングの色を変更する
-        /// </summary>
-        private void ResetRingsColor(Color color, Color translucentColor)
-        {
-			_ringImage.color = color;
-			_hitImage.color = color;
-			_decorationImage.color = color;
-			
-			//  フェードアウトしているのでここでリセットをかける
-			_centerImage.color = Color.white;
-        }
-
         #endregion
 
 		protected override void HandlePerfect() => OnPlayerAvoidSuccess(true);

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -190,29 +190,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             }
         }
 
-        /// <summary>
-        /// プレイヤーが回避に失敗したときのアニメーション
-        /// </summary>
-        public void PlayFailEffect()
-        {
-            if(_tweens != null)
-            {
-                _tweens[0]?.Kill();
-            }
-			
-			SetMissImage();
-			
-            var failSequence = DOTween.Sequence();
-
-            // 色変更とフェードアウト
-            failSequence.Append(CreateColorChangeSequence(Color.darkGray, Color.darkGray, _fadeDuration));
-            failSequence.Join(CreateFadeSequence(_fadeDuration));
-
-            failSequence.OnComplete(End);
-            
-            _tweens[0] = failSequence;
-        }
-
 		protected override void HandlePerfect() => OnPlayerAvoidSuccess(true);
         protected override void HandleGood() => OnPlayerAvoidSuccess(false);
     }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -23,10 +23,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
             switch (count)
             {
-                // 1拍目　点滅して表示 -> 1拍目から縮小するように修正
+                // 1拍目　縮小エフェクトを開始する
                 case 1:
-                    InitializeComponents();
-                    // StartBlinkEffect(); // 警告のような点滅アニメーション
                     StartContractionEffect(); // 収縮アニメーション
                     break;
 				

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -140,6 +140,9 @@ namespace BeatKeeper.Runtime.Ingame.UI
 			contractionSequence.Append(_ringImage.rectTransform.DOScale(Vector3.one * 0.5f, beatDuration * RECEPTION_TIME).SetEase(Ease.Linear));
 			contractionSequence.Join(CreateFadeSequence(beatDuration * RECEPTION_TIME));
 
+            // シーケンスが中断されなかった場合はミス。失敗演出を行う
+            contractionSequence.OnComplete(() => PlayFailEffect());
+            
             // Tweenを配列に保存
             if (_tweens != null && _tweens.Length > 1)
             {
@@ -208,6 +211,11 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// </summary>
         public void PlayFailEffect()
         {
+            if(_tweens != null)
+            {
+                _tweens[0]?.Kill();
+            }
+            
             // 回避失敗フラグを立てる
             _isFailed = true;
 
@@ -223,6 +231,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             failSequence.Join(CreateFadeSequence(_fadeDuration));
 
             failSequence.OnComplete(End);
+            
+            _tweens[0] = failSequence;
         }
 
         #region Reset

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -38,8 +38,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
 				
 				// 	誤反応対策として念のために直前にイベント登録を行う
 				case 2:
-					_player.OnPerfectAvoid += HandlePerfectAvoid;
-					_player.OnGoodAvoid += HandleGoodAvoid;
+					_player.OnPerfectAvoid += HandlePerfect;
+					_player.OnGoodAvoid += HandleGood;
                     _player.OnFailedAvoid += PlayFailEffect;
 					break;
             }
@@ -53,8 +53,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             ResetAllTween();
 
             // イベント購読解除
-            _player.OnPerfectAvoid -= HandlePerfectAvoid;
-            _player.OnGoodAvoid -= HandleGoodAvoid;
+            _player.OnPerfectAvoid -= HandlePerfect;
+            _player.OnGoodAvoid -= HandleGood;
             _player.OnFailedAvoid -= PlayFailEffect;
 
             base.End();
@@ -276,40 +276,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
         #endregion
 
-        #region Create Sequence
-
-        /// <summary>
-        /// フェードアウトシーケンスを作成
-        /// </summary>
-        private DG.Tweening.Sequence CreateFadeSequence(float duration)
-        {
-            var fadeSequence = DOTween.Sequence();
-			
-			fadeSequence.Join(_ringImage.DOFade(0f, duration).SetEase(Ease.Linear));
-			fadeSequence.Join(_hitImage.DOFade(0f, duration).SetEase(Ease.Linear));
-			fadeSequence.Join(_decorationImage.DOFade(0f, duration).SetEase(Ease.Linear));
-			fadeSequence.Join(_centerImage.DOFade(0f, duration).SetEase(Ease.Linear));
-
-            return fadeSequence;
-        }
-
-        /// <summary>
-        /// 色変更シーケンスを作成
-        /// </summary>
-        private DG.Tweening.Sequence CreateColorChangeSequence(Color targetColor, Color translucentColor, float duration)
-        {
-            var colorSequence = DOTween.Sequence();
-
-			colorSequence.Join(_ringImage.DOColor(targetColor, duration).SetEase(Ease.OutFlash));
-			colorSequence.Join(_hitImage.DOColor(targetColor, duration).SetEase(Ease.OutFlash));
-			colorSequence.Join(_decorationImage.DOColor(targetColor, duration).SetEase(Ease.OutFlash));
-
-            return colorSequence;
-        }
-
-		private void HandlePerfectAvoid() => OnPlayerAvoidSuccess(true);
-        private void HandleGoodAvoid() => OnPlayerAvoidSuccess(false);
-
-        #endregion
+		protected override void HandlePerfect() => OnPlayerAvoidSuccess(true);
+        protected override void HandleGood() => OnPlayerAvoidSuccess(false);
     }
 }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -45,10 +45,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _player.OnFailedAvoid -= PlayFailEffect;
 
             base.End();
-            
-            // UIのリセット
-            ResetRingsScale();
-            ResetRingsColor(_defaultColor, _translucentDefaultColor);
 
             //敵攻撃はノックバックを与えるので確認
             _chartRingManager.CheckAllRingIndicatorRemainTime();

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -65,29 +65,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         
         #endregion
 
-        [Header("追加の色設定")]
-        [SerializeField] private Color _warningColor = Color.red;
-
-        private void Start()
-        {
-			_centerImage.enabled = true;
-            ResetRingsScale();
-            ResetRingsColor(_defaultColor, _translucentDefaultColor);
-        }
-
-        /// <summary>
-        /// コンポーネントの初期化
-        /// </summary>
-        private void InitializeComponents()
-        {
-            // Tweenの配列を作成
-            _tweens = new Tween[3];
-
-            // 初期状態の設定
-            ResetRingsScale();
-            ResetRingsColor(_defaultColor, _translucentDefaultColor);
-        }
-
 		protected override void HandlePerfect() => OnPlayerSuccess(true);
         protected override void HandleGood() => OnPlayerSuccess(false);
     }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/EnemyIndicator.cs
@@ -55,6 +55,15 @@ namespace BeatKeeper.Runtime.Ingame.UI
             //敵攻撃はノックバックを与えるので確認
             _chartRingManager.CheckAllRingIndicatorRemainTime();
         }
+        
+        #region チュートリアル用のメソッド
+
+        public void OnPlayerAvoidSuccess(bool isPerfect)
+        {
+            OnPlayerSuccess(isPerfect);
+        }
+        
+        #endregion
 
         private const float CONTRACTION_SPEED = 2; // 収縮にかける拍
 		// Justタイミングのあとの判定受付時間 // TODO: PlayerDataから値をとってくるようにする
@@ -149,48 +158,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
             }
         }
 
-        /// <summary>
-        /// プレイヤーが回避に成功したときに再生する回避成功エフェクト
-        /// </summary>
-        public void OnPlayerAvoidSuccess(bool isPerfect)
-        {
-            if (MusicEngineHelper.GetBeatNearerSinceStart() != _timing)
-            {
-                // ノーツのタイミングより前なら処理はスキップ
-                return;
-            }
-            
-			// 成功した場合はリングの縮小演出は不要になるのでキル
-            if(_tweens != null)
-			{
-				_tweens[0]?.Kill();
-			}
-
-			if (isPerfect)
-            {
-                // パーフェクト判定の場合は収縮するリングのScaleを1に補正
-                _ringImage.rectTransform.localScale = Vector3.one;
-            }
-
-			HandleCenterImage(isPerfect);
-			ChangeRingsImage();
-
-            var successSequence = DOTween.Sequence();
-
-            // パンチスケール
-            successSequence.Append(_selfImage.rectTransform.DOPunchScale(Vector3.one * 0.65f, _blinkDuration, 2, 0.5f));
-            successSequence.Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration));
-
-			// フェードアウト
-            successSequence.Append(CreateFadeSequence(_fadeDuration));
-
-            // エフェクトが完了したらEnd処理を実行
-            successSequence.OnComplete(End);
-
-            _tweens[0] = successSequence;
-        }
-
-		protected override void HandlePerfect() => OnPlayerAvoidSuccess(true);
-        protected override void HandleGood() => OnPlayerAvoidSuccess(false);
+		protected override void HandlePerfect() => OnPlayerSuccess(true);
+        protected override void HandleGood() => OnPlayerSuccess(false);
     }
 }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -30,16 +30,16 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 
                 // 2拍目　念のため判定が始まる2拍目のタイミングでアクション登録を行う
                 case 2:
-                    _player.OnPerfectAttack += HandlePerfectAttack;
-                    _player.OnGoodAttack += HandleGoodAttack;
+                    _player.OnPerfectAttack += HandlePerfect;
+                    _player.OnGoodAttack += HandleGood;
                     break;
             }
         }
 
         public override void End()
         {
-            _player.OnPerfectAttack -= HandlePerfectAttack;
-            _player.OnGoodAttack -= HandleGoodAttack;
+            _player.OnPerfectAttack -= HandlePerfect;
+            _player.OnGoodAttack -= HandleGood;
 
 			base.End();
             
@@ -282,7 +282,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
             return colorSequence;
         }
         
-        private void HandlePerfectAttack() => OnPlayerAttackSuccess(true);
-        private void HandleGoodAttack() => OnPlayerAttackSuccess(false);
+        protected override void HandlePerfect() => OnPlayerAttackSuccess(true);
+        protected override void HandleGood() => OnPlayerAttackSuccess(false);
     }
 }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -41,10 +41,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _player.OnGoodAttack -= HandleGood;
 
 			base.End();
-            
-            // NOTE: InitializeComponents()より先に表示されてしまうのでここでも初期化を行う
-            ResetRingsScale();
-            ResetRingsColor(_defaultColor, _translucentDefaultColor);
         }
 
         #region チュートリアル用のメソッド

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -254,34 +254,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             if(_hitImage != null) _hitImage.color = color;
         }
         
-        /// <summary>
-        /// フェードアウトシーケンスを作成
-        /// </summary>
-        private DG.Tweening.Sequence CreateFadeSequence(float duration)
-        {
-            var fadeSequence = DOTween.Sequence();
-            
-            if (_ringImage != null) fadeSequence.Join(_ringImage.DOFade(0f, duration).SetEase(Ease.Linear));
-            if (_decorationImage != null) fadeSequence.Join(_decorationImage.DOFade(0f, duration).SetEase(Ease.Linear));
-            if (_hitImage != null) fadeSequence.Join(_hitImage.DOFade(0f, duration).SetEase(Ease.Linear));
-            
-            return fadeSequence;
-        }
-        
-        /// <summary>
-        /// 色変更シーケンスを作成
-        /// </summary>
-        private DG.Tweening.Sequence CreateColorChangeSequence(Color targetColor, Color translucentColor, float duration)
-        {
-            var colorSequence = DOTween.Sequence();
-            
-            if (_ringImage != null) colorSequence.Join(_ringImage.DOColor(targetColor, duration).SetEase(Ease.OutFlash));
-            if (_decorationImage != null) colorSequence.Join(_decorationImage.DOColor(targetColor, duration).SetEase(Ease.OutFlash));
-            if (_hitImage != null) colorSequence.Join(_hitImage.DOColor(targetColor, duration).SetEase(Ease.OutFlash));
-            
-            return colorSequence;
-        }
-        
         protected override void HandlePerfect() => OnPlayerAttackSuccess(true);
         protected override void HandleGood() => OnPlayerAttackSuccess(false);
     }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -61,11 +61,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         public void PlayGoodEffect() => OnPlayerSuccessForced(false);
         
         #endregion
-        
-        // Justタイミングは2拍後
-        private const float CONTRACTION_SPEED = 2;
-        // Justタイミングのあとの判定受付時間 // TODO: PlayerDataから値をとってくるようにする
-        private const float RECEPTION_TIME = 0.45f;
 
         private void Start()
         {
@@ -84,37 +79,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             // スケールと色を初期化
             ResetRingsScale();
             ResetRingsColor(_defaultColor, _translucentDefaultColor);
-        }
-        
-        /// <summary>
-        /// リングの縮小
-        /// </summary>
-        private void StartContractionEffect()
-        {
-            // 一拍が何秒か、アニメーションのために値をキャッシュしておく
-            var beatDuration = (float)MusicEngineHelper.DurationOfBeat;
-
-            var sequence = DOTween.Sequence()
-                
-                // Just判定まで縮小を行う
-                .Append(_ringImage.rectTransform.DOScale(Vector3.one, beatDuration * CONTRACTION_SPEED).SetEase(Ease.Linear))
-                
-                // Just判定を過ぎたら縮小は続行しつつ段々フェードアウトする
-                .Append(_ringImage.rectTransform.DOScale(Vector3.one * 0.5f, beatDuration * RECEPTION_TIME).SetEase(Ease.Linear))
-                .Join(CreateFadeSequence(beatDuration * RECEPTION_TIME))
-                
-                // シーケンスが中断されなかった場合はミス。失敗演出を行う
-                .OnComplete(() => PlayFailEffect());
-            
-            _tweens[0] = sequence;
-            
-            // ブラーリングのパルス
-            var blurPulseSequence = DOTween.Sequence()
-                .Append(_decorationImage.DOFade(_translucentDefaultColor.a * 1.5f, beatDuration * 0.5f).SetEase(Ease.OutSine))
-                .Append(_decorationImage.DOFade(_translucentDefaultColor.a, beatDuration * 0.5f).SetEase(Ease.InSine))
-                .SetLoops(-1, LoopType.Restart);
-            
-            _tweens[1] = blurPulseSequence;
         }
         
         protected override void HandlePerfect() => OnPlayerSuccess(true);

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -108,32 +108,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
             _tweens[0] = successSequence;
         }
-
-
-        /// <summary>
-        /// 失敗演出
-        /// </summary>
-        public void PlayFailEffect()
-        {
-			if(_tweens != null)
-			{
-				_tweens[0]?.Kill();
-			}
-
-            // 中央のImageのスプライトとサイズをMissのものに変える
-            SetMissImage();
-
-            var failSequence = DOTween.Sequence();
-
-            // 色変更とフェードアウト
-            failSequence.Append(CreateColorChangeSequence(Color.darkGray, Color.darkGray, _fadeDuration));
-            failSequence.Join(CreateFadeSequence(_fadeDuration));
-
-            failSequence.OnComplete(End);
-
-            _tweens[0] = failSequence;
-        }
-
+        
         // Justタイミングは2拍後
         private const float CONTRACTION_SPEED = 2;
         // Justタイミングのあとの判定受付時間 // TODO: PlayerDataから値をとってくるようにする

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -62,25 +62,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         
         #endregion
 
-        private void Start()
-        {
-            ResetRingsScale();
-            ResetRingsColor(_defaultColor, _translucentDefaultColor);
-        }
-        
-        /// <summary>
-        /// コンポーネントの初期化
-        /// </summary>
-        private void InitializeComponents()
-        {
-            // 2種類のTweenを使用するため、配列も2つ分確保する
-            _tweens = new Tween[2];
-            
-            // スケールと色を初期化
-            ResetRingsScale();
-            ResetRingsColor(_defaultColor, _translucentDefaultColor);
-        }
-        
         protected override void HandlePerfect() => OnPlayerSuccess(true);
         protected override void HandleGood() => OnPlayerSuccess(false);
     }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -48,6 +48,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             ResetRingsColor(_defaultColor, _translucentDefaultColor);
         }
 
+        #region チュートリアル用のメソッド
+        
         /// <summary>
         /// Perfect判定時のエフェクト
         /// </summary>
@@ -109,6 +111,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _tweens[0] = successSequence;
         }
         
+        #endregion
+        
         // Justタイミングは2拍後
         private const float CONTRACTION_SPEED = 2;
         // Justタイミングのあとの判定受付時間 // TODO: PlayerDataから値をとってくるようにする
@@ -163,54 +167,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             
             _tweens[1] = blurPulseSequence;
         }
-
-        /// <summary>
-        /// 当たりエフェクト（プレイヤーが攻撃に成功したときに再生）
-        /// </summary>
-        private void OnPlayerAttackSuccess(bool isPerfect)
-        {
-            if (MusicEngineHelper.GetBeatNearerSinceStart() != _timing)
-            {
-                // ノーツのタイミングより前なら処理はスキップ
-                return;
-            }
-
-            // 成功した場合はリングの縮小演出は不要になるのでキル
-            if(_tweens != null)
-			{
-				_tweens[0]?.Kill();
-			}
-            
-            if (isPerfect)
-            {
-                // パーフェクト判定の場合は収縮するリングのScaleを1に補正
-                _ringImage.rectTransform.localScale = Vector3.one;
-            }
-
-            // 中央の画像を判定用の画像に変更
-            HandleCenterImage(isPerfect);
-
-			// 白色のSpriteに変更
-			ChangeRingsImage();
-            
-            var successSequence = DOTween.Sequence();
-
-            // パンチスケールと色変更
-            successSequence.Append(_selfImage.rectTransform.DOPunchScale(Vector3.one * 0.65f, _blinkDuration, 2, 0.5f));
-            successSequence.Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration));
-            
-            // フェードアウト
-            successSequence.Append(CreateFadeSequence(_fadeDuration));
-
-            // エフェクトが完了したらEnd処理を実行
-            successSequence.OnComplete(End);
-
-            _tweens[0] = successSequence;
-        }
-
-		
         
-        protected override void HandlePerfect() => OnPlayerAttackSuccess(true);
-        protected override void HandleGood() => OnPlayerAttackSuccess(false);
+        protected override void HandlePerfect() => OnPlayerSuccess(true);
+        protected override void HandleGood() => OnPlayerSuccess(false);
     }
 }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -49,67 +49,16 @@ namespace BeatKeeper.Runtime.Ingame.UI
         }
 
         #region チュートリアル用のメソッド
-        
+
         /// <summary>
         /// Perfect判定時のエフェクト
         /// </summary>
-        public void PlayPerfectEffect()
-        {
-            if(_tweens != null)
-			{
-				_tweens[0]?.Kill();
-			}
-
-            // パーフェクト判定の場合は収縮するリングのScaleを1に補正
-            _ringImage.rectTransform.localScale = Vector3.one;
-
-            // 中央のImageのスプライトとサイズをPerfectのものに変える
-            HandleCenterImage(true);
-			ChangeRingsImage();
-
-            var successSequence = DOTween.Sequence();
-
-            // パンチスケールと色変更
-            successSequence.Append(_selfImage.rectTransform.DOPunchScale(Vector3.one * 0.65f, _blinkDuration, 2, 0.5f));
-            successSequence.Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration));
-
-            // フェードアウト
-            successSequence.Append(CreateFadeSequence(_fadeDuration));
-
-            // エフェクトが完了したらEnd処理を実行
-            successSequence.OnComplete(End);
-
-            _tweens[0] = successSequence;
-        }
+        public void PlayPerfectEffect() => OnPlayerSuccessForced(true);
 
         /// <summary>
         /// Good判定時のエフェクト
         /// </summary>
-        public void PlayGoodEffect()
-        {
-            if(_tweens != null)
-			{
-				_tweens[0]?.Kill();
-			}
-
-            // 中央のImageのスプライトとサイズをGoodのものに変える
-            HandleCenterImage(false);
-			ChangeRingsImage();
-
-            var successSequence = DOTween.Sequence();
-
-            // パンチスケールと色変更
-            successSequence.Append(_selfImage.rectTransform.DOPunchScale(Vector3.one * 0.65f, _blinkDuration, 2, 0.5f));
-            successSequence.Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration));
-
-            // フェードアウト
-            successSequence.Append(CreateFadeSequence(_fadeDuration));
-
-            // エフェクトが完了したらEnd処理を実行
-            successSequence.OnComplete(End);
-
-            _tweens[0] = successSequence;
-        }
+        public void PlayGoodEffect() => OnPlayerSuccessForced(false);
         
         #endregion
         

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -233,26 +233,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _tweens[0] = successSequence;
         }
 
-		/// <summary>
-        /// 各リングの拡大率を変更する
-        /// </summary>
-		private void ResetRingsScale()
-		{
-			if(_selfImage != null) _selfImage.rectTransform.localScale = Vector3.one;
-			if(_ringImage != null) _ringImage.rectTransform.localScale = Vector3.one * _initialScale;
-			if(_decorationImage != null) _decorationImage.rectTransform.localScale = _centerRingsScale;
-			if(_hitImage != null) _hitImage.rectTransform.localScale = _centerRingsScale;
-		}
-        
-        /// <summary>
-        /// 各リングの色を変更する
-        /// </summary>
-        private void ResetRingsColor(Color color, Color translucentColor)
-        {
-            if(_ringImage != null) _ringImage.color = color;
-            if(_decorationImage != null) _decorationImage.color = color;
-            if(_hitImage != null) _hitImage.color = color;
-        }
+		
         
         protected override void HandlePerfect() => OnPlayerAttackSuccess(true);
         protected override void HandleGood() => OnPlayerAttackSuccess(false);

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/PlayerIndicator.cs
@@ -24,7 +24,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             {
                 // 1拍目　縮小エフェクトを開始する
                 case 1:
-                    InitializeComponents();
                     StartContractionEffect();
                     break;
                 

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -299,6 +299,54 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _hitImage.sprite = _commonSprite.HitLine;
         }
         
+        #region ノーツの演出（protectedメソッド）
+        
+        /// <summary>
+        /// 成功エフェクト
+        /// </summary>
+        protected virtual void OnPlayerSuccess(bool isPerfect)
+        {
+            if (MusicEngineHelper.GetBeatNearerSinceStart() != _timing)
+            {
+                // ノーツのタイミングより前なら処理はスキップ
+                return;
+            }
+
+            // 成功した場合はリングの縮小演出は不要になるのでキル
+            if(_tweens != null)
+            {
+                _tweens[0]?.Kill();
+            }
+            
+            if (isPerfect)
+            {
+                // パーフェクト判定の場合は収縮するリングのScaleを1に補正
+                _ringImage.rectTransform.localScale = Vector3.one;
+            }
+
+            // 中央の画像を判定用の画像に変更
+            HandleCenterImage(isPerfect);
+
+            // 白色のSpriteに変更
+            ChangeRingsImage();
+            
+            var successSequence = DOTween.Sequence();
+
+            // パンチスケールと色変更
+            successSequence.Append(_selfImage.rectTransform.DOPunchScale(Vector3.one * 0.65f, _blinkDuration, 2, 0.5f));
+            successSequence.Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration));
+            
+            // フェードアウト
+            successSequence.Append(CreateFadeSequence(_fadeDuration));
+
+            // エフェクトが完了したらEnd処理を実行
+            successSequence.OnComplete(End);
+
+            _tweens[0] = successSequence;
+        }
+        
+        #endregion
+        
         #region リングのコンポーネント全てのScale、色のリセット
         
         /// <summary>

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -303,6 +303,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         
         /// <summary>
         /// 成功エフェクト
+        /// NOTE: スキルノーツ、チャージノーツはオーバーライドして実装
         /// </summary>
         protected virtual void OnPlayerSuccess(bool isPerfect)
         {
@@ -311,7 +312,14 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 // ノーツのタイミングより前なら処理はスキップ
                 return;
             }
+            OnPlayerSuccess(isPerfect);
+        }
 
+        /// <summary>
+        /// タイミングチェックなしで強制的に成功エフェクトを再生
+        /// </summary>
+        protected virtual void OnPlayerSuccessForced(bool isPerfect)
+        {
             // 成功した場合はリングの縮小演出は不要になるのでキル
             if(_tweens != null)
             {

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -284,7 +284,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         
         #endregion
         
-        #region シーケンス作成メソッド（通常攻撃/回避で使用。スキル/チャージは継承したもの）
+        #region シーケンス作成メソッド（通常攻撃/回避で使用。スキル/チャージはオーバーライドしてそれぞれ独自処理を実装する）
         
         /// <summary>
         /// フェードアウトシーケンスを作成

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -310,10 +310,10 @@ namespace BeatKeeper.Runtime.Ingame.UI
             var contractionSequence = DOTween.Sequence()
 
                 // Just判定まで縮小を行う
-                .Append(_ringImage.rectTransform.DOScale(Vector3.one, beatDuration * CONTRACTION_SPEED).SetEase(Ease.Linear))
+                .Append(_ringImage.rectTransform.DOScale(_centerRingsScale, beatDuration * CONTRACTION_SPEED).SetEase(Ease.Linear))
                 
                 // Just判定を過ぎたら縮小は続行しつつ段々フェードアウトする
-                .Append(_ringImage.rectTransform.DOScale(Vector3.one * 0.5f, beatDuration * RECEPTION_TIME).SetEase(Ease.Linear))
+                .Append(_ringImage.rectTransform.DOScale(_centerRingsScale * 0.5f, beatDuration * RECEPTION_TIME).SetEase(Ease.Linear))
                 .Join(CreateFadeSequence(beatDuration * RECEPTION_TIME))
                 
                 // シーケンスが中断されなかった場合はミス。失敗演出を行う

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -270,6 +270,30 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _hitImage.sprite = _commonSprite.HitLine;
         }
         
+        #region リングのコンポーネント全てのScale、色のリセット
+        
+        /// <summary>
+        /// 各リングの拡大率を変更する
+        /// </summary>
+        protected virtual void ResetRingsScale()
+        {
+            if(_ringImage != null) _ringImage.rectTransform.localScale = Vector3.one * _initialScale;
+            if(_decorationImage != null) _decorationImage.rectTransform.localScale = _centerRingsScale;
+            if(_hitImage != null) _hitImage.rectTransform.localScale = _centerRingsScale;
+        }
+        
+        /// <summary>
+        /// 各リングの色を変更する
+        /// </summary>
+        protected virtual void ResetRingsColor(Color color, Color translucentColor)
+        {
+            if(_ringImage != null) _ringImage.color = color;
+            if(_decorationImage != null) _decorationImage.color = color;
+            if(_hitImage != null) _hitImage.color = color;
+        }
+        
+        #endregion
+        
         #region PlayerManagerのイベント登録用
         
         /// <summary>

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -34,6 +34,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _selfImage.rectTransform.position = rectPos
                 + new Vector2(Screen.width / 2, Screen.height / 2);
 
+            // 初期化
+            InitializeComponents();
             UIInitialized();
 
             _onEndAction = onEndAction;
@@ -53,6 +55,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
             // 終了フラグをリセット
             _isEnded = false;
 
+            // 初期化
             UIInitialized();
 
             _onEndAction = onEndAction;
@@ -244,43 +247,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         }
 
         /// <summary>
-        /// コンポーネントの初期化
-        /// </summary>
-        protected virtual void InitializeComponents()
-        {
-            // 2種類のTweenを使用するため、配列も2つ分確保する
-            _tweens = new Tween[2];
-            
-            // スケールと色を初期化
-            ResetRingsScale();
-            ResetRingsColor(_defaultColor, _translucentDefaultColor);
-        }
-        
-        /// <summary>
-        /// UIの初期化処理
-        /// オブジェクトプールのOnGet()処理の中で呼び出される
-        /// </summary>
-        protected virtual void UIInitialized()
-        {
-            if (_hitLine == null && _decoration == null && _ring == null)
-            {
-                // 初期画像を取得する
-                _hitLine = _ringImage.sprite;
-                _decoration = _decorationImage.sprite;
-                _ring = _hitImage.sprite;
-            }
-
-            // 中央のリングの画像を操作方法のものに差し替える
-            _centerImage.sprite = _guide.Sprite;
-            _centerImage.rectTransform.sizeDelta = _guide.SizeDelta;
-
-            // デフォルトのスプライトを設定する
-            _ringImage.sprite = _hitLine;
-            _decorationImage.sprite = _decoration;
-            _hitImage.sprite = _ring;
-        }
-
-        /// <summary>
         /// Perfect/Goodの色変更用にSpriteを白色のものに変更する
         /// </summary>
         protected virtual void ChangeRingsImage()
@@ -422,7 +388,45 @@ namespace BeatKeeper.Runtime.Ingame.UI
         
         #endregion
         
-        #region リングのコンポーネント全てのScale、色のリセット
+        #region リングのコンポーネント全てのScale、色の初期化・リセット
+        
+        /// <summary>
+        /// コンポーネントの初期化
+        /// NOTE: スキル、チャージノーツはオーバーライドして実装
+        /// </summary>
+        protected virtual void InitializeComponents()
+        {
+            // 2種類のTweenを使用するため、配列も2つ分確保する
+            _tweens = new Tween[2];
+            
+            // スケールと色を初期化
+            ResetRingsScale();
+            ResetRingsColor(_defaultColor, _translucentDefaultColor);
+        }
+        
+        /// <summary>
+        /// UIの初期化処理
+        /// オブジェクトプールのOnGet()処理の中で呼び出される
+        /// </summary>
+        protected virtual void UIInitialized()
+        {
+            if (_hitLine == null && _decoration == null && _ring == null)
+            {
+                // 初期画像を取得する
+                _hitLine = _ringImage.sprite;
+                _decoration = _decorationImage.sprite;
+                _ring = _hitImage.sprite;
+            }
+
+            // 中央のリングの画像を操作方法のものに差し替える
+            _centerImage.sprite = _guide.Sprite;
+            _centerImage.rectTransform.sizeDelta = _guide.SizeDelta;
+
+            // デフォルトのスプライトを設定する
+            _ringImage.sprite = _hitLine;
+            _decorationImage.sprite = _decoration;
+            _hitImage.sprite = _ring;
+        }
         
         /// <summary>
         /// 各リングの拡大率を変更する

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -208,7 +208,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
         // 判定に合わせて適用する色を変えるための変数
         protected Color _newColor;
         protected Color _newTranslucentColor;
-
         protected bool _isEnded = false;
         protected int _timing;
         protected int _count;
@@ -219,6 +218,11 @@ namespace BeatKeeper.Runtime.Ingame.UI
         protected Color _defaultColor => _colorSettings.DefaultColor;
         protected Color _translucentDefaultColor => _colorSettings.TranslucentDefaultColor;
 
+        // Justタイミングは2拍後
+        private const float CONTRACTION_SPEED = 2;
+        // Justタイミングのあとの判定受付時間 // TODO: PlayerDataから値をとってくるようにする
+        private const float RECEPTION_TIME = 0.45f;
+        
         private void Awake()
         {
             _selfImage = GetComponent<Image>();
@@ -230,38 +234,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             }
 
             _defaultCenterImageSize = _centerImage.rectTransform.sizeDelta;
-        }
-
-        /// <summary>
-        /// 中央のイメージを操作する
-        /// </summary>
-        protected void HandleCenterImage(bool isPerfect)
-        {
-            var hitResult = isPerfect ? _hitResult.Perfect : _hitResult.Good;
-
-            // 中央のImageのスプライト変更とサイズ変更
-            _centerImage.sprite = hitResult.Sprite;
-            _centerImage.rectTransform.sizeDelta = hitResult.SizeDelta;
-
-            if (isPerfect)
-            {
-                _newColor = _colorSettings.PerfectColor;
-                _newTranslucentColor = _colorSettings.TranslucentPerfectColor;
-            }
-            else
-            {
-                _newColor = _colorSettings.GoodColor;
-                _newTranslucentColor = _colorSettings.TranslucentGoodColor;
-            }
-        }
-
-        /// <summary>
-        /// 中央のイメージをMiss判定のものに差し替える
-        /// </summary>
-        protected void SetMissImage()
-        {
-            _centerImage.sprite = _hitResult.Miss.Sprite;
-            _centerImage.rectTransform.sizeDelta = _hitResult.Miss.SizeDelta;
         }
 
         /// <summary>
@@ -299,7 +271,82 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _hitImage.sprite = _commonSprite.HitLine;
         }
         
+        #region 中央画像の操作（操作アイコン・判定の画像）
+        
+        /// <summary>
+        /// 中央のイメージを操作する
+        /// </summary>
+        protected void HandleCenterImage(bool isPerfect)
+        {
+            var hitResult = isPerfect ? _hitResult.Perfect : _hitResult.Good;
+
+            // 中央のImageのスプライト変更とサイズ変更
+            _centerImage.sprite = hitResult.Sprite;
+            _centerImage.rectTransform.sizeDelta = hitResult.SizeDelta;
+
+            if (isPerfect)
+            {
+                _newColor = _colorSettings.PerfectColor;
+                _newTranslucentColor = _colorSettings.TranslucentPerfectColor;
+            }
+            else
+            {
+                _newColor = _colorSettings.GoodColor;
+                _newTranslucentColor = _colorSettings.TranslucentGoodColor;
+            }
+        }
+
+        /// <summary>
+        /// 中央のイメージをMiss判定のものに差し替える
+        /// </summary>
+        protected void SetMissImage()
+        {
+            _centerImage.sprite = _hitResult.Miss.Sprite;
+            _centerImage.rectTransform.sizeDelta = _hitResult.Miss.SizeDelta;
+        }
+        
+        #endregion
+        
         #region ノーツの演出（protectedメソッド）
+
+        /// <summary>
+        /// 縮小演出
+        /// </summary>
+        protected virtual void StartContractionEffect()
+        {
+            // 一拍が何秒か、アニメーションのために値をキャッシュしておく
+            var beatDuration = (float)MusicEngineHelper.DurationOfBeat;
+
+            var contractionSequence = DOTween.Sequence()
+
+                // Just判定まで縮小を行う
+                .Append(_ringImage.rectTransform.DOScale(Vector3.one, beatDuration * CONTRACTION_SPEED).SetEase(Ease.Linear))
+                
+                // Just判定を過ぎたら縮小は続行しつつ段々フェードアウトする
+                .Append(_ringImage.rectTransform.DOScale(Vector3.one * 0.5f, beatDuration * RECEPTION_TIME).SetEase(Ease.Linear))
+                .Join(CreateFadeSequence(beatDuration * RECEPTION_TIME))
+                
+                // シーケンスが中断されなかった場合はミス。失敗演出を行う
+                .OnComplete(() => PlayFailEffect());
+            
+            // Tweenを配列に保存
+            if (_tweens != null && _tweens.Length > 1)
+            {
+                _tweens[0] = contractionSequence;
+            }
+
+            // ブラーリングのパルス
+            var blurPulseSequence = DOTween.Sequence()
+                .Append(_decorationImage.DOFade(_translucentDefaultColor.a * 1.5f, beatDuration * 0.5f).SetEase(Ease.OutSine))
+                .Append(_decorationImage.DOFade(_translucentDefaultColor.a, beatDuration * 0.5f).SetEase(Ease.InSine))
+                .SetLoops(-1, LoopType.Restart);
+
+            // Tweenを配列に保存
+            if (_tweens != null && _tweens.Length > 1)
+            {
+                _tweens[1] = blurPulseSequence;
+            }
+        }
         
         /// <summary>
         /// 成功エフェクト

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -270,6 +270,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _hitImage.sprite = _commonSprite.HitLine;
         }
         
+        #region PlayerManagerのイベント登録用
+        
         /// <summary>
         /// Perfect判定時の処理
         /// </summary>
@@ -280,5 +282,39 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// </summary>
         protected virtual void HandleGood(){ }
         
+        #endregion
+        
+        #region シーケンス作成メソッド（通常攻撃/回避で使用。スキル/チャージは継承したもの）
+        
+        /// <summary>
+        /// フェードアウトシーケンスを作成
+        /// </summary>
+        protected virtual DG.Tweening.Sequence CreateFadeSequence(float duration)
+        {
+            var fadeSequence = DOTween.Sequence();
+			
+            fadeSequence.Join(_ringImage.DOFade(0f, duration).SetEase(Ease.Linear));
+            fadeSequence.Join(_hitImage.DOFade(0f, duration).SetEase(Ease.Linear));
+            fadeSequence.Join(_decorationImage.DOFade(0f, duration).SetEase(Ease.Linear));
+            // fadeSequence.Join(_centerImage.DOFade(0f, duration).SetEase(Ease.Linear));
+
+            return fadeSequence;
+        }
+
+        /// <summary>
+        /// 色変更シーケンスを作成
+        /// </summary>
+        protected virtual DG.Tweening.Sequence CreateColorChangeSequence(Color targetColor, Color translucentColor, float duration)
+        {
+            var colorSequence = DOTween.Sequence();
+
+            colorSequence.Join(_ringImage.DOColor(targetColor, duration).SetEase(Ease.OutFlash));
+            colorSequence.Join(_hitImage.DOColor(targetColor, duration).SetEase(Ease.OutFlash));
+            colorSequence.Join(_decorationImage.DOColor(targetColor, duration).SetEase(Ease.OutFlash));
+			
+            return colorSequence;
+        }
+        
+        #endregion
     }
 }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -120,6 +120,54 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
             return true;
         }
+        
+        #region ノーツの演出メソッド
+        
+        /// <summary>
+        /// 失敗演出
+        /// NOTE: チャージのみ使用しているコンポーネントが多いためオーバーライドして実装が必要
+        /// </summary>
+        public virtual void PlayFailEffect()
+        {
+            if (_tweens != null)
+            {
+                // 念のためキルしておく
+                _tweens[0]?.Kill();
+            }
+            
+            // 中央のImageのスプライトとサイズをMissのものに変える
+            SetMissImage();
+            
+            var failSequence = DOTween.Sequence();
+            
+            // 色変更とフェードアウト
+            failSequence.Append(CreateColorChangeSequence(Color.darkGray, Color.darkGray, _fadeDuration));
+            failSequence.Join(CreateFadeSequence(_fadeDuration));
+            
+            failSequence.OnComplete(End);
+            
+            _tweens[0] = failSequence;
+        }
+        
+        #endregion
+        
+        public virtual void Pause()
+        {
+            if (_tweens == null) return;
+            foreach (var tween in _tweens)
+            {
+                tween?.Pause();
+            }
+        }
+
+        public virtual void Resume()
+        {
+            if (_tweens == null) return;
+            foreach (var tween in _tweens)
+            {
+                tween?.Play();
+            }
+        }
 
         [Header("基本設定")]
         [SerializeField] protected float _initialScale = 3.5f;
@@ -170,25 +218,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
         protected Color _defaultColor => _colorSettings.DefaultColor;
         protected Color _translucentDefaultColor => _colorSettings.TranslucentDefaultColor;
-
-        public virtual void Pause()
-        {
-            if (_tweens == null) return;
-            foreach (var tween in _tweens)
-            {
-                tween?.Pause();
-            }
-        }
-
-        public virtual void Resume()
-        {
-            if (_tweens == null) return;
-            foreach (var tween in _tweens)
-            {
-                tween?.Play();
-            }
-        }
-
 
         private void Awake()
         {

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -269,5 +269,16 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _decorationImage.sprite = _commonSprite.Decoration;
             _hitImage.sprite = _commonSprite.HitLine;
         }
+        
+        /// <summary>
+        /// Perfect判定時の処理
+        /// </summary>
+        protected virtual void HandlePerfect(){ }
+        
+        /// <summary>
+        /// Good判定時の処理
+        /// </summary>
+        protected virtual void HandleGood(){ }
+        
     }
 }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -121,7 +121,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
             return true;
         }
         
-        #region ノーツの演出メソッド
+        #region ノーツの演出（チュートリアル用publicメソッド）
         
         /// <summary>
         /// 失敗演出
@@ -168,6 +168,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 tween?.Play();
             }
         }
+        
+        #region 変数宣言
 
         [Header("基本設定")]
         [SerializeField] protected float _initialScale = 3.5f;
@@ -223,6 +225,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
         // Justタイミングのあとの判定受付時間 // TODO: PlayerDataから値をとってくるようにする
         private const float RECEPTION_TIME = 0.45f;
         
+        #endregion
+        
         private void Awake()
         {
             _selfImage = GetComponent<Image>();
@@ -234,8 +238,24 @@ namespace BeatKeeper.Runtime.Ingame.UI
             }
 
             _defaultCenterImageSize = _centerImage.rectTransform.sizeDelta;
+            
+            ResetRingsScale();
+            ResetRingsColor(_defaultColor, _translucentDefaultColor);
         }
 
+        /// <summary>
+        /// コンポーネントの初期化
+        /// </summary>
+        protected virtual void InitializeComponents()
+        {
+            // 2種類のTweenを使用するため、配列も2つ分確保する
+            _tweens = new Tween[2];
+            
+            // スケールと色を初期化
+            ResetRingsScale();
+            ResetRingsColor(_defaultColor, _translucentDefaultColor);
+        }
+        
         /// <summary>
         /// UIの初期化処理
         /// オブジェクトプールのOnGet()処理の中で呼び出される
@@ -359,7 +379,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 // ノーツのタイミングより前なら処理はスキップ
                 return;
             }
-            OnPlayerSuccess(isPerfect);
+            OnPlayerSuccessForced(isPerfect);
         }
 
         /// <summary>

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/RingIndicatorBase.cs
@@ -84,6 +84,10 @@ namespace BeatKeeper.Runtime.Ingame.UI
             }
 
             _onEndAction?.Invoke();
+            
+            // UIのリセット
+            ResetRingsScale();
+            ResetRingsColor(_defaultColor, _translucentDefaultColor);
         }
 
         public void AddCount()

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -31,20 +31,20 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 
                 // 3拍目　スキル発動の演出を行う
                 case 2:
-                    _player.OnPerfectSkill += HandlePerfectSkill;
-                    _player.OnGoodSkill += HandleGoodSkill;
+                    _player.OnPerfectSkill += HandlePerfect;
+                    _player.OnGoodSkill += HandleGood;
                     
                     // TODO: 仮
-                    _player.OnFinisher += HandlePerfectSkill;
+                    _player.OnFinisher += HandlePerfect;
                     break;
             }
         }
         
         public override void End()
         {
-            _player.OnPerfectSkill -= HandlePerfectSkill;
-            _player.OnGoodSkill -= HandleGoodSkill;
-            _player.OnFinisher -= HandlePerfectSkill;
+            _player.OnPerfectSkill -= HandlePerfect;
+            _player.OnGoodSkill -= HandleGood;
+            _player.OnFinisher -= HandlePerfect;
             
             // フィニッシャー状態の監視を解除
             StopFinisherMonitoring();
@@ -384,7 +384,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// フェードアウトシーケンスを作成
         /// </summary>
-        private DG.Tweening.Sequence CreateFadeSequence(float duration)
+        protected override DG.Tweening.Sequence CreateFadeSequence(float duration)
         {
             var fadeSequence = DOTween.Sequence();
             
@@ -411,7 +411,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// 色変更シーケンスを作成
         /// </summary>
-        private DG.Tweening.Sequence CreateColorChangeSequence(Color targetColor, Color translucentColor, float duration)
+        protected override DG.Tweening.Sequence CreateColorChangeSequence(Color targetColor, Color translucentColor, float duration)
         {
             var colorSequence = DOTween.Sequence();
             
@@ -435,7 +435,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
             return colorSequence;
         }
         
-        private void HandlePerfectSkill() => PlaySuccessEffect(true);
-        private void HandleGoodSkill() => PlaySuccessEffect(false);
+        protected override void HandlePerfect() => PlaySuccessEffect(true);
+        protected override void HandleGood() => PlaySuccessEffect(false);
     }
 }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -212,31 +212,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             _tweens[0] = successSequence;
         }
 
-        /// <summary>
-        /// 失敗演出
-        /// </summary>
-        public void PlayFailEffect()
-        {
-            if (_tweens != null)
-            {
-                // 念のためキルしておく
-                _tweens[0]?.Kill();
-            }
-            
-            // 中央のImageのスプライトとサイズをMissのものに変える
-            SetMissImage();
-            
-            var failSequence = DOTween.Sequence();
-            
-            // 色変更とフェードアウト
-            failSequence.Append(CreateColorChangeSequence(Color.darkGray, Color.darkGray, _fadeDuration));
-            failSequence.Join(CreateFadeSequence(_fadeDuration));
-            
-            failSequence.OnComplete(End);
-            
-            _tweens[0] = failSequence;
-        }
-
         #region スキル/フィニッシャーの切り替え
         
         /// <summary>

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -56,6 +56,22 @@ namespace BeatKeeper.Runtime.Ingame.UI
             ResetRingsColor(_defaultColor, _translucentDefaultColor);
             UpdateRingState();
         }
+        
+        #region チュートリアル用のメソッド
+        
+        /// <summary>
+        /// 発動エフェクト
+        /// </summary>
+        public void PlaySuccessEffectPublic()
+        {
+            // パーフェクト判定の場合は収縮するリングのScaleを1に補正
+            // フィニッシャーノーツのリングの操作。ベースクラスの処理に含まれないのでここで行う
+            _ringImages[0].rectTransform.localScale = Vector3.one;
+
+            base.OnPlayerSuccessForced(true);
+        }
+        
+        #endregion
 
         // Justタイミングは2拍後
         private const float CONTRACTION_SPEED = 2;
@@ -135,37 +151,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 .SetLoops(-1, LoopType.Restart);
             
             _tweens[1] = blurPulseSequence;
-        }
-
-        /// <summary>
-        /// 発動エフェクト
-        /// </summary>
-        public void PlaySuccessEffectPublic()
-        {
-            if(_tweens != null)
-            {
-                _tweens[0]?.Kill();
-            }
-            
-            // パーフェクト判定の場合は収縮するリングのScaleを1に補正
-            _ringImage.rectTransform.localScale = Vector3.one;
-
-            HandleCenterImage(true);
-            ChangeRingsImage();
-            
-            var successSequence = DOTween.Sequence();
-
-            // パンチスケールと色変更
-            successSequence.Append(_selfImage.rectTransform.DOPunchScale(Vector3.one * 0.65f, _blinkDuration, 2, 0.5f));
-            successSequence.Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration));
-
-            // フェードアウト
-            successSequence.Append(CreateFadeSequence(_fadeDuration));
-
-            // エフェクトが完了したらEnd処理を実行
-            successSequence.OnComplete(End);
-
-            _tweens[0] = successSequence;
         }
 
         /// <summary>

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -25,7 +25,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
             {
                 // 1拍目　縮小エフェクトを開始する
                 case 1:
-                    InitializeComponents();
                     StartContractionEffect();
                     break;
                 
@@ -94,7 +93,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// コンポーネントの初期化
         /// </summary>
-        protected virtual void InitializeComponents()
+        protected override void InitializeComponents()
         {
             // 2種類のTweenを使用するため、配列も2つ分確保する
             _tweens = new Tween[3];
@@ -239,6 +238,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// </summary>
         private void SwitchCanvasGroup()
         {
+            if (_tweens == null || _tweens.Length < 3) return;
+            
             if(_tweens != null)
             {
                 // 既にTweenがあったらKill

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -177,39 +177,16 @@ namespace BeatKeeper.Runtime.Ingame.UI
             {
                 // ノーツのタイミングより前なら処理はスキップ
                 return;
-            }   
-            
-            // 成功した場合はリングの縮小演出は不要になるのでキル
-            if(_tweens != null)
-            {
-                _tweens[0]?.Kill();
             }
 
             if (isPerfect)
             {
                 // パーフェクト判定の場合は収縮するリングのScaleを1に補正
-                _ringImage.rectTransform.localScale = Vector3.one;
+                // フィニッシャーノーツのリングの操作。ベースクラスの処理に含まれないのでここで行う
                 _ringImages[0].rectTransform.localScale = Vector3.one;
             }
-
-            // 中央の画像を判定用の画像に変更
-            // NOTE: この処理を呼ばないと、この後に使用される「_newColor」が更新されない
-            HandleCenterImage(isPerfect);
-            ChangeRingsImage();
-           
-            var successSequence = DOTween.Sequence();
-
-            // パンチスケールと色変更
-            successSequence.Append(_selfImage.rectTransform.DOPunchScale(Vector3.one * 0.65f, _blinkDuration, 2, 0.5f));
-			successSequence.Join(CreateColorChangeSequence(_newColor, _newTranslucentColor, _fadeDuration));            
-
-            // フェードアウト
-            successSequence.Append(CreateFadeSequence(_fadeDuration));
-
-            // エフェクトが完了したらEnd処理を実行
-            successSequence.OnComplete(End);
-
-            _tweens[0] = successSequence;
+            
+            base.PlayFailEffect();
         }
 
         #region スキル/フィニッシャーの切り替え
@@ -418,7 +395,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         
         #endregion
         
-        protected override void HandlePerfect() => PlaySuccessEffect(true);
-        protected override void HandleGood() => PlaySuccessEffect(false);
+        protected override void HandlePerfect() => OnPlayerSuccess(true);
+        protected override void HandleGood() => OnPlayerSuccess(false);
     }
 }

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -50,9 +50,6 @@ namespace BeatKeeper.Runtime.Ingame.UI
 
             base.End();
             
-            // NOTE: InitializeComponents()より先に表示されてしまうのでここでも初期化を行う
-            ResetRingsScale();
-            ResetRingsColor(_defaultColor, _translucentDefaultColor);
             UpdateRingState();
         }
         

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -109,7 +109,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// リングの縮小
         /// </summary>
-        private void StartContractionEffect()
+        protected virtual void StartContractionEffect()
         {
             // 一拍が何秒か、アニメーションのために値をキャッシュしておく
             var beatDuration = (float)MusicEngineHelper.DurationOfBeat;

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -332,11 +332,21 @@ namespace BeatKeeper.Runtime.Ingame.UI
         }
         
         #endregion
-
+        
+        /// <summary>
+        /// 個別リングのスケール設定（nullチェック付き）
+        /// </summary>
+        private void SetRingScale(Image ring, Vector3 scale)
+        {
+            if (ring != null) ring.rectTransform.localScale = scale;
+        }
+        
+        #region リングのコンポーネント全てのScale、色のリセット
+        
         /// <summary>
         /// 各リングの拡大率を変更する
         /// </summary>
-        private void ResetRingsScale()
+        protected override void ResetRingsScale()
         {
             // 収縮を行うリング
             SetRingScale(_ringImage, Vector3.one * _initialScale);
@@ -354,17 +364,9 @@ namespace BeatKeeper.Runtime.Ingame.UI
         }
         
         /// <summary>
-        /// 個別リングのスケール設定（nullチェック付き）
-        /// </summary>
-        private void SetRingScale(Image ring, Vector3 scale)
-        {
-            if (ring != null) ring.rectTransform.localScale = scale;
-        }
-        
-        /// <summary>
         /// 各リングの色を変更する
         /// </summary>
-        private void ResetRingsColor(Color color, Color translucentColor)
+        protected override void ResetRingsColor(Color color, Color translucentColor)
         {
             _ringImage.color = color;
             _hitImage.color = color;
@@ -380,6 +382,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
                 ring.color = translucentColor;
             }
         }
+        
+        #endregion
         
         #region シーケンス作成メソッド
         

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -94,7 +94,7 @@ namespace BeatKeeper.Runtime.Ingame.UI
         /// <summary>
         /// コンポーネントの初期化
         /// </summary>
-        private void InitializeComponents()
+        protected virtual void InitializeComponents()
         {
             // 2種類のTweenを使用するため、配列も2つ分確保する
             _tweens = new Tween[3];
@@ -105,6 +105,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             // 初回のフィニッシャー状態をチェックしてUI更新
             UpdateRingState();
         }
+        
+        #region 演出メソッド
         
         /// <summary>
         /// リングの縮小
@@ -173,6 +175,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             
             base.PlayFailEffect();
         }
+        
+        #endregion
 
         #region スキル/フィニッシャーの切り替え
         

--- a/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
+++ b/Assets/Scripts/Runtime/Ingame/UI/Battle/Indicator/SpecialIndicator.cs
@@ -381,6 +381,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             }
         }
         
+        #region シーケンス作成メソッド
+        
         /// <summary>
         /// フェードアウトシーケンスを作成
         /// </summary>
@@ -434,6 +436,8 @@ namespace BeatKeeper.Runtime.Ingame.UI
             
             return colorSequence;
         }
+        
+        #endregion
         
         protected override void HandlePerfect() => PlaySuccessEffect(true);
         protected override void HandleGood() => PlaySuccessEffect(false);


### PR DESCRIPTION
ノーツクラスのリファクタリング

バグの修正内容
- 回避ノーツが消えずに残ってしまう
- 回避ノーツの演出が通常攻撃などと異なる
- 長押しノーツのMiss表示が出ない
- 長押しノーツ成功後のノーツImageの色が濁っている