### PR TITLE
[fix]譜面が重複して流れるバグを修正

### DIFF
--- a/Assets/Scripts/Runtime/Ingame/Battle/Character/Enemy/EnemyManager.cs
+++ b/Assets/Scripts/Runtime/Ingame/Battle/Character/Enemy/EnemyManager.cs
@@ -34,7 +34,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
         public void Dispose()
         {
             InputUnregister();
-            _disposeCancellationToken?.Cancel();
+            _disposable?.Dispose();
         }
 
         public EnemyAnimeManager GetEnemyAnimeManager()
@@ -81,14 +81,14 @@ namespace BeatKeeper.Runtime.Ingame.Character
 
             SetActiveModel(true);
 
-            _disposeCancellationToken = new();
+            _disposable = new();
             
             //フェーズ変更時のイベント登録
             var phaseManager = ServiceLocator.GetInstance<PhaseManager>();
             phaseManager.CurrentPhaseProp
                 .Skip(1) // 初期フェーズをスキップ
                 .Subscribe(OnPhaseChange)
-                .AddTo(_disposeCancellationToken.Token);
+                .AddTo(_disposable);
             _phaseManager = phaseManager;
         }
 
@@ -170,7 +170,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
         private EnemyAnimeManager _animeManager;
         private CharacterHealthSystem _healthSystem;
 
-        private CancellationTokenSource _disposeCancellationToken = new CancellationTokenSource();
+        private CompositeDisposable _disposable = new CompositeDisposable();
 
         protected override async void Awake()
         {
@@ -225,7 +225,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
         }
 
         private void OnAttack()
-        {
+        {   
             if (!_bgmManager) return;
 
             if (_target.IsStunning()) return; //プレイヤーがスタン中は攻撃しない

--- a/Assets/Scripts/Runtime/Ingame/System/Stage/StageEnemyAdmin.cs
+++ b/Assets/Scripts/Runtime/Ingame/System/Stage/StageEnemyAdmin.cs
@@ -37,8 +37,6 @@ namespace BeatKeeper.Runtime.Ingame.Battle
 
             if (nextIndex >= _enemies.Length) return;
             
-            _activeEnemyIndex = nextIndex;
-
             // 次の敵をアクティブに設定
             SetActiveEnemy(nextIndex);
             // イベントを発火


### PR DESCRIPTION
ディスコ―ドのほうでも報告したこと

・StageEnemyAdminの部分のindex管理的に、前フェーズの敵の非アクティブ処理が適切に呼ばれていなかった
・EnemyManager内でフェーズ切り替わりタイミングを購読しているが、その解除にCancellationTokenSourceが使われていた部分をCompositeDisposableに置き換えた