### PR TITLE
見逃しミスの修正

### DIFF
--- a/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
+++ b/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
@@ -1092,8 +1092,10 @@ namespace BeatKeeper.Runtime.Ingame.Character
                 {
                     missedFlag = true;
                     OnShootComboAttack -= action;
+                    OnMissAttack -= action;
                 };
                 OnShootComboAttack += action;
+                OnMissAttack += action;
             }
             else if (kind == ChartKindEnum.Charge)
             {
@@ -1101,8 +1103,10 @@ namespace BeatKeeper.Runtime.Ingame.Character
                 {
                     missedFlag = true;
                     OnChargeAttack -= action;
+                    OnMissChargeAttack -= action;
                 };
                 OnChargeAttack += action;
+                OnMissChargeAttack += action;
             }
             else if (isCharging)
             {
@@ -1110,8 +1114,10 @@ namespace BeatKeeper.Runtime.Ingame.Character
                 {
                     missedFlag = true;
                     OnCharging -= action;
+                    OnMissedCharging -= action;
                 };
                 OnCharging += action;
+                OnMissedCharging += action;
             }
             else if (kind == ChartKindEnum.Normal)
             {
@@ -1119,8 +1125,11 @@ namespace BeatKeeper.Runtime.Ingame.Character
                 {
                     missedFlag = true;
                     OnSuccessAvoid -= action;
+                    OnFailedAvoid -= action;
                 };
                 OnSuccessAvoid += action;
+                OnFailedAvoid += action;
+
             }
             else if (kind == ChartKindEnum.Skill)
             {
@@ -1128,24 +1137,43 @@ namespace BeatKeeper.Runtime.Ingame.Character
                 {
                     missedFlag = true;
                     OnSkill -= action;
+                    OnMissedSkill -= action;
                     OnFinisher -= action;
                 };
                 OnSkill += action;
+                OnMissedSkill += action;
                 OnFinisher += action;
             }
 
             float timer = Time.time + duration; //拍が終わるタイミング
             await SymphonyTask.WaitUntil(() => timer < Time.time || missedFlag);
 
-            if (kind == ChartKindEnum.Attack) OnShootComboAttack -= action;
-            else if (kind == ChartKindEnum.Charge) OnChargeAttack -= action;
-            else if (isCharging) OnCharging -= action;
+            if (kind == ChartKindEnum.Attack)
+            {
+                OnShootComboAttack -= action;
+                OnMissAttack -= action;
+            }
+            else if (kind == ChartKindEnum.Charge)
+            {
+                OnChargeAttack -= action;
+                OnMissChargeAttack -= action;
+            }
+            else if (isCharging)
+            {
+                OnCharging -= action;
+                OnMissedCharging -= action;
+            }
             else if (kind == ChartKindEnum.Normal)
             {
                 OnSuccessAvoid -= action;
+                OnFailedAvoid -= action;
+            }
+            else if (kind == ChartKindEnum.Skill)
+            {
+                OnSkill -= action;
+                OnMissedSkill -= action;
                 OnFinisher -= action;
             }
-            else if (kind == ChartKindEnum.Skill) OnSkill -= action;
 
             if (missedFlag) return; //成功していたら何もしない
 

--- a/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
+++ b/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
@@ -629,6 +629,12 @@ namespace BeatKeeper.Runtime.Ingame.Character
             if (_isBattle)
             {
                 MissedChart();
+                Debug.Log($"on near beat {Time.time} {MusicEngineHelper.GetBeatSinceStart()}");
+            }
+
+            if (_isMissed)
+            {
+                _isMissed = false;
             }
 
             if (IsResetComboAttackCounter())
@@ -717,6 +723,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
         private void AttackFlow()
         {
             if (_target == null) return;
+            if (_isMissed) return;
 
             SymphonyDebugLogger.AddText($"{_data.Name} do attack");
 
@@ -758,6 +765,8 @@ namespace BeatKeeper.Runtime.Ingame.Character
         /// </summary>
         private void SKillFlow()
         {
+            if (_isMissed) return;
+
             bool isPerfect = MusicEngineHelper
                 .IsTimingWithinAcceptableRange(_data.PerfectSkillRange);
             bool isGood = MusicEngineHelper
@@ -839,6 +848,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
             OnMissAttack?.Invoke();
             _comboSystem.ComboReset();
             _comboAttackCounter.Value = 0; //コンボカウンターをリセット
+            _isMissed = true;
         }
 
         /// <summary>
@@ -882,6 +892,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
             Debug.Log("miss skill");
             _comboSystem?.ComboReset();
             OnMissedSkill?.Invoke();
+            _isMissed = true;
         }
 
 
@@ -890,6 +901,8 @@ namespace BeatKeeper.Runtime.Ingame.Character
         /// </summary>
         private async void ChargeAttackCharging()
         {
+            if (_isMissed) return;
+
             bool isPerfecet = MusicEngineHelper.IsTimingWithinAcceptableRange(_data.ChargeStartPerfectRange);
             bool isGood = MusicEngineHelper.IsTimingWithinAcceptableRange(_data.ChargeStartGoodRange);
 
@@ -937,6 +950,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
 
             _comboSystem.ComboReset();
             OnMissedCharging?.Invoke();
+            _isMissed = true;
         }
 
         /// <summary>
@@ -944,6 +958,8 @@ namespace BeatKeeper.Runtime.Ingame.Character
         /// </summary>
         private void ChargeAttackActivation()
         {
+            if (_isMissed) return;
+
             bool isPerfect = MusicEngineHelper.IsTimingWithinAcceptableRange(_data.ChargeEndPerfectRange);
             bool isGood = MusicEngineHelper.IsTimingWithinAcceptableRange(_data.ChargeEndGoodRange);
 
@@ -972,6 +988,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
             Debug.Log("miss charge attack");
             OnMissChargeAttack?.Invoke();
             _comboSystem.ComboReset();
+            _isMissed = true;
         }
 
         /// <summary>
@@ -1032,6 +1049,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
         private void MissedAvoid()
         {
             OnFailedAvoid?.Invoke();
+            _isMissed = true;
         }
 
         /// <summary>
@@ -1149,7 +1167,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
             }
 
             float timer = Time.time + duration; //拍が終わるタイミング
-
+            Debug.Log($"miss timer {timer} {timing}");
             try
             {
                 await SymphonyTask.WaitUntil(() => timer < Time.time || missedFlag,
@@ -1187,6 +1205,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
             }
 
             if (missedFlag) return; // 成功していたら何もしない。
+            if (_isMissed) return; // 既にミス処理が行われていたら実行されない。
 
             switch (kind)
             {

--- a/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
+++ b/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
@@ -1146,54 +1146,61 @@ namespace BeatKeeper.Runtime.Ingame.Character
             }
 
             float timer = Time.time + duration; //拍が終わるタイミング
-            await SymphonyTask.WaitUntil(() => timer < Time.time || missedFlag);
 
-            if (kind == ChartKindEnum.Attack)
+            try
             {
-                OnShootComboAttack -= action;
-                OnMissAttack -= action;
+                await SymphonyTask.WaitUntil(() => timer < Time.time || missedFlag,
+                    destroyCancellationToken);
             }
-            else if (kind == ChartKindEnum.Charge)
+            finally
             {
-                OnChargeAttack -= action;
-                OnMissChargeAttack -= action;
-            }
-            else if (isCharging)
-            {
-                OnCharging -= action;
-                OnMissedCharging -= action;
-            }
-            else if (kind == ChartKindEnum.Normal)
-            {
-                OnSuccessAvoid -= action;
-                OnFailedAvoid -= action;
-            }
-            else if (kind == ChartKindEnum.Skill)
-            {
-                OnSkill -= action;
-                OnMissedSkill -= action;
-                OnFinisher -= action;
+                if (kind == ChartKindEnum.Attack)
+                {
+                    OnShootComboAttack -= action;
+                    OnMissAttack -= action;
+                }
+                else if (kind == ChartKindEnum.Charge)
+                {
+                    OnChargeAttack -= action;
+                    OnMissChargeAttack -= action;
+                }
+                else if (isCharging)
+                {
+                    OnCharging -= action;
+                    OnMissedCharging -= action;
+                }
+                else if (kind == ChartKindEnum.Normal)
+                {
+                    OnSuccessAvoid -= action;
+                    OnFailedAvoid -= action;
+                }
+                else if (kind == ChartKindEnum.Skill)
+                {
+                    OnSkill -= action;
+                    OnMissedSkill -= action;
+                    OnFinisher -= action;
+                }
             }
 
-            if (missedFlag) return; //成功していたら何もしない
+            if (missedFlag) return; // 成功していたら何もしない。
 
             switch (kind)
             {
-                case ChartKindEnum.Attack:
+                case ChartKindEnum.Attack: //コンボ攻撃の時。
                     MissAttack();
                     break;
-                case ChartKindEnum.Charge:
+                case ChartKindEnum.Charge: // チャージ発射の時。
                     MissedChargeAttack();
                     break;
-                case ChartKindEnum.Skill:
+                case ChartKindEnum.Skill: // スキルの時。
                     MissSkill();
                     break;
-                case ChartKindEnum.Normal:
+                case ChartKindEnum.Normal: // 回避の時。
                     MissedAvoid();
                     break;
             }
 
-            if (isCharging)
+            if (isCharging) // チャージ開始の時。
             {
                 MissedCharging();
             }

--- a/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
+++ b/Assets/Scripts/Runtime/Ingame/Battle/Character/Player/PlayerManager.cs
@@ -30,17 +30,16 @@ namespace BeatKeeper.Runtime.Ingame.Character
         public event Action OnGoodAttack;
         public event Action OnMissAttack;
 
-        public event Action OnStartChargeAttack
-        {
-            add => _onStartChargeAttack.Event += value;
-            remove => _onStartChargeAttack.Event -= value;
-        }
         public event Action OnChargeAttack;
         public event Action OnPerfectChargeAttack;
         public event Action OnGoodChargeAttack;
         public event Action OnMissChargeAttack;
 
-        public event Action OnCharging;
+        public event Action OnCharging
+        {
+            add => _onStartChargeAttack.Event += value;
+            remove => _onStartChargeAttack.Event -= value;
+        }
         public event Action OnPerfectCharging;
         public event Action OnGoodCharging;
         public event Action OnMissedCharging;
@@ -318,6 +317,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
         private FlowZoneSystem _flowZoneSystem;
         private SkillSystem _skillSystem;
 
+        private bool _isMissed = false;
         #endregion
 
         #region 開発用の機能
@@ -1047,7 +1047,9 @@ namespace BeatKeeper.Runtime.Ingame.Character
             if (!_ringIndicatorData.TryGetRingData(kind, out RingData data)) return false;
             int effectLength = data.EffectLength;
 
-            float startTiming = Time.time - (float)MusicEngineHelper.DurationOfBeat * effectLength;
+            float startTiming = Time.time - 
+                (float)MusicEngineHelper.DurationOfBeat 
+                * (effectLength - 1); // 1オリジンのため
             return _phaseManager.IsAnotherPhaseByTiming(startTiming);
         }
 
@@ -1058,7 +1060,8 @@ namespace BeatKeeper.Runtime.Ingame.Character
         {
             if (_target == null) return;
 
-            int timing = MusicEngineHelper.GetBeatSinceStart() + 1;
+            // 次のノーツを取得する
+            int timing = MusicEngineHelper.GetBeatSinceStart() + 1; 
             ChartData chart = _target.EnemyData
                 .GetChartDataByFlowZone(_flowZoneSystem.IsFlowZone.CurrentValue);
             ChartKindEnum kind = chart[timing].AttackKind;
@@ -1154,6 +1157,7 @@ namespace BeatKeeper.Runtime.Ingame.Character
             }
             finally
             {
+                // イベントの解放処理
                 if (kind == ChartKindEnum.Attack)
                 {
                     OnShootComboAttack -= action;


### PR DESCRIPTION
#351 チャージノーツの3拍前を常に監視して判定するように
#352 とりあえず、effectLengthにオフセットを与えている
#325 ミスのフラグを作ってミス移行に攻撃できないように